### PR TITLE
Add gender symbols (Proposal 1)

### DIFF
--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -1347,6 +1347,7 @@ train 🚆
   .suspend 🚟
   .tram 🚊
   .tram.car 🚋
+transgender ⚧
 tray
   .inbox 📥
   .mail 📨

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -1347,7 +1347,6 @@ train 🚆
   .suspend 🚟
   .tram 🚊
   .tram.car 🚋
-transgender ⚧
 tray
   .inbox 📥
   .mail 📨

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1026,3 +1026,18 @@ Im ℑ
 dotless
   .i ı
   .j ȷ
+
+gender {
+  female ♀
+    .double ⚢
+    .male ⚤
+  intersex ⚥
+  male ♂
+    .double ⚣
+    .female ⚤
+    .stroke ⚦
+    .stroke.t ⚨
+    .stroke.r ⚩
+  neuter ⚲
+  trans ⚧
+}


### PR DESCRIPTION
## Description

This PR implements Proposal 1 (iteration ~2~ 3) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds gender symbols under a new `sym.gender` sub-module, ~and removes the old `emoji.transgender` symbol~.

## Breaking changes (cc. @laurmaedje)
~`emoji.transgender` is no longer valid.~ No breaking change as of iteration 3 (07bfd3134a695a990e9fd197be909fd7db28de0e).