### PR TITLE
Add die face symbols (Proposal 2)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1026,3 +1026,11 @@ Im ℑ
 dotless
   .i ı
   .j ȷ
+
+die
+  .six ⚅
+  .five ⚄
+  .four ⚃
+  .three ⚂
+  .two ⚁
+  .one ⚀

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1027,6 +1027,7 @@ dotless
   .i ı
   .j ȷ
 
+// Miscellany.
 die
   .six ⚅
   .five ⚄


### PR DESCRIPTION
This PR implements Proposal 2 (iteration 1) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds die face symbols as `die.{one,two,three,four,five,six}`, with `die.six` being the default.