### PR TITLE
Add missing `divides` variants (Proposal 4)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -502,6 +502,8 @@ miny ⧿
 // Number theory.
 divides ∣
   .not ∤
+  .not.rev ⫮
+  .struck ⟊
 
 // Algebra.
 wreath ≀


### PR DESCRIPTION
This PR implements Proposal 4 (iteration 1) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds two `divides` variants: `divides.not.rev`, and `divides.struck`.