### PR TITLE
Add interleave symbol and variants (Proposal 3)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -524,6 +524,9 @@ perp ⟂
 
 // Miscellaneous Technical.
 diameter ⌀
+interleave ⫴
+  .big ⫼
+  .struck ⫵
 join ⨝
   .r ⟖
   .l ⟕


### PR DESCRIPTION
This PR implements Proposal 3 (iteration 3) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds an `interleave` symbol and two variants.