### PR TITLE
Sort members of `codex::ROOT`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,26 @@ pub enum Symbol {
 
 /// A module that contains the other top-level modules.
 pub const ROOT: Module =
-    Module(&[("sym", Def::Module(SYM)), ("emoji", Def::Module(EMOJI))]);
+    Module(&[("emoji", Def::Module(EMOJI)), ("sym", Def::Module(SYM))]);
 
 include!(concat!(env!("OUT_DIR"), "/out.rs"));
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn all_modules_sorted() {
+        fn assert_sorted_recursively(root: Module) {
+            assert!(root.0.is_sorted_by_key(|(k, _)| k));
+
+            for (_, def) in root.iter() {
+                if let Def::Module(module) = def {
+                    assert_sorted_recursively(module)
+                }
+            }
+        }
+
+        assert_sorted_recursively(ROOT);
+    }
+}


### PR DESCRIPTION
This is a bit of a 'how did we not catch this earlier?' story, but in all fairness this repository is only 5 days old.
I was checking out the Rust API when I noticed `ROOT.get("sym")` returned `None`—after which I came to realise `ROOT`'s members weren't sorted in key-order, meaning the `binary_search_by_key` call didn't uphold its preconditions :P

I simply swapped the order of `SYM` and `EMOJI` in `ROOT`'s definition and added a test to ensure all modules remain sorted indefinitely.

@laurmaedje I do think this fix warrants a new release to crates.io, this was a slightly major bug.
