### PR TITLE
Add error bar symbols (Proposal 12)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1040,3 +1040,10 @@ die
   .three ⚂
   .two ⚁
   .one ⚀
+error
+  .square.stroked ⧮
+  .square.filled ⧯
+  .diamond.stroked ⧰
+  .diamond.filled ⧱
+  .circle.stroked ⧲
+  .circle.filled ⧳

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1040,7 +1040,7 @@ die
   .three ⚂
   .two ⚁
   .one ⚀
-error
+errorbar
   .square.stroked ⧮
   .square.filled ⧯
   .diamond.stroked ⧰


### PR DESCRIPTION
This PR implements Proposal 12 (iteration 3) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds a new `errorbar` symbol with multiple variants.