### PR TITLE
Add smaller than and larger than symbols (Proposal 11)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -358,6 +358,10 @@ succ ≻
   .tilde ≿
 equiv ≡
   .not ≢
+smt ⪪
+  .eq ⪬
+lat ⪫
+  .eq ⪭
 prop ∝
 original ⊶
 image ⊷


### PR DESCRIPTION
This PR implements Proposal 11 (iteration 1) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds new `smt` and `lat` symbols with `.eq` variants.