### PR TITLE
Remove compatibility symbols (Proposal 19)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -67,11 +67,11 @@ angle ∠
   .l ⟨
   .l.curly ⧼
   .l.dot ⦑
-  .l.double 《
+  .l.double ⟪
   .r ⟩
   .r.curly ⧽
   .r.dot ⦒
-  .r.double 》
+  .r.double ⟫
   .acute ⦟
   .arc ∡
   .arc.rev ⦛
@@ -532,8 +532,6 @@ join ⨝
   .l ⟕
   .l.r ⟗
 degree °
-  .c ℃
-  .f ℉
 smash ⨳
 
 // Currency.
@@ -931,8 +929,6 @@ kappa κ
 lambda λ
 mu μ
 nu ν
-ohm Ω
-  .inv ℧
 omega ω
 omicron ο
 phi φ
@@ -1024,13 +1020,12 @@ ZZ ℤ
 ell ℓ
 planck ℎ
   .reduce ℏ
-angstrom Å
-kelvin K
 Re ℜ
 Im ℑ
 dotless
   .i ı
   .j ȷ
+mho ℧
 
 // Miscellany.
 die

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -962,6 +962,7 @@ Lambda Λ
 Mu Μ
 Nu Ν
 Omega Ω
+  .inv ℧
 Omicron Ο
 Phi Φ
 Pi Π
@@ -1025,7 +1026,6 @@ Im ℑ
 dotless
   .i ı
   .j ȷ
-mho ℧
 
 // Miscellany.
 die


### PR DESCRIPTION
## Description

This PR implements Proposal 19 (~iteration 1~ iteration 2) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It removes compatibility codepoints. For some context, see [the Unit Symbols paragraphs of section 22.2.1 of the Unicode 16.0.0 Core Specification](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-22/#G20445), as well as the description of Proposal 19 in the aforementioned Symbol Proposals document (copied below for simplicity).
<!-- ![Proposal 19 (iteration 1).](https://github.com/user-attachments/assets/b211bfcb-cdad-48d5-8b6a-c25687339307) -->
![Proposal 19 (iteration 2).](https://github.com/user-attachments/assets/96ee96ab-71d8-4e75-aa1d-5f94cab4aa4e)

## Breaking changes (cc. @laurmaedje)

`angle.l.double` and `angle.r.double` change codepoints. `degree.c`, `degree.f`, `ohm`, `ohm.inv`, `angstrom`, and `kelvin` become invalid.