### PR TITLE
Add `inter` as an alternative for `sect` (Proposal 14, part I)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -433,6 +433,15 @@ union ∪
   .sq ⊔
   .sq.big ⨆
   .sq.double ⩏
+inter ∩
+  .and ⩄
+  .big ⋂
+  .dot ⩀
+  .double ⋒
+  .sq ⊓
+  .sq.big ⨅
+  .sq.double ⩎
+# Deprecation planned.
 sect ∩
   .and ⩄
   .big ⋂
@@ -467,6 +476,8 @@ integral ∫
   .dash.double ⨎
   .double ∬
   .quad ⨌
+  .inter ⨙
+  # Deprecation planned.
   .sect ⨙
   .slash ⨏
   .square ⨖

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -441,7 +441,7 @@ inter ∩
   .sq ⊓
   .sq.big ⨅
   .sq.double ⩎
-# Deprecation planned.
+// Deprecation planned.
 sect ∩
   .and ⩄
   .big ⋂
@@ -477,7 +477,7 @@ integral ∫
   .double ∬
   .quad ⨌
   .inter ⨙
-  # Deprecation planned.
+  // Deprecation planned.
   .sect ⨙
   .slash ⨏
   .square ⨖

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -441,7 +441,7 @@ inter ∩
   .sq ⊓
   .sq.big ⨅
   .sq.double ⩎
-// Deprecation planned.
+@deprecated: `sect` is deprecated and replaced with `inter`
 sect ∩
   .and ⩄
   .big ⋂

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -477,7 +477,7 @@ integral ∫
   .double ∬
   .quad ⨌
   .inter ⨙
-  // Deprecation planned.
+  // Deprecated.
   .sect ⨙
   .slash ⨏
   .square ⨖

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -441,7 +441,7 @@ inter ∩
   .sq ⊓
   .sq.big ⨅
   .sq.double ⩎
-@deprecated: `sect` is deprecated and replaced with `inter`
+@deprecated: `sect` is deprecated, use `inter` instead
 sect ∩
   .and ⩄
   .big ⋂


### PR DESCRIPTION
This PR implements the first part of Proposal 14 (iteration 1) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds `inter` as an alternative for `sect`. Eventually, `sect` should be deprecated, and later removed. For more context, see [the discussion on Discord](https://discord.com/channels/1054443721975922748/1277628305142452306/1311370099382292520).

For now, there is no infrastructure to deprecate symbols in Codex, nor is there a way to deprecate a constant in Typst. This makes it impossible to deprecate `sect` immediately. However, since `sect` is a commonly used symbol, I believe the sooner we introduce its new name, the better.

Since this PR assumes the future removal of a symbol (`sect`) and a variant (`integral.sect`), and even though this was already discussed on Discord, cc. @laurmaedje.