### PR TITLE
Add math styling module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ readme = "README.md"
 license = "Apache-2.0"
 categories = ["encoding", "text-processing"]
 keywords = ["unicode", "symbols"]
+
+[features]
+default = ["styling"]
+styling = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ pub use self::shared::ModifierSet;
 
 mod shared;
 
+#[cfg(feature = "styling")]
+pub mod styling;
+
 /// A module of definitions.
 #[derive(Debug, Copy, Clone)]
 pub struct Module(&'static [(&'static str, Binding)]);

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -907,23 +907,27 @@ mod conversions {
     pub fn to_chancery(c: char) -> [char; 2] {
         // Standardized Variation Sequences (uppercase Latin script characters)
         // Variation Sequences (lowercase Latin script characters)
-        [to_script(c), VARIATION_SELECTOR_1]
+        let next = if is_latin(c) { VARIATION_SELECTOR_1 } else { '\0' };
+        [to_script(c), next]
     }
 
     pub fn to_bold_chancery(c: char) -> [char; 2] {
         // Variation Sequences (Latin script characters)
-        [to_bold_script(c), VARIATION_SELECTOR_1]
+        let next = if is_latin(c) { VARIATION_SELECTOR_1 } else { '\0' };
+        [to_bold_script(c), next]
     }
 
     pub fn to_roundhand(c: char) -> [char; 2] {
         // Standardized Variation Sequences (uppercase Latin script characters)
         // Variation Sequences (lowercase Latin script characters)
-        [to_script(c), VARIATION_SELECTOR_2]
+        let next = if is_latin(c) { VARIATION_SELECTOR_2 } else { '\0' };
+        [to_script(c), next]
     }
 
     pub fn to_bold_roundhand(c: char) -> [char; 2] {
         // Variation Sequences (Latin script characters)
-        [to_bold_script(c), VARIATION_SELECTOR_2]
+        let next = if is_latin(c) { VARIATION_SELECTOR_2 } else { '\0' };
+        [to_bold_script(c), next]
     }
 
     pub fn to_hebrew(c: char) -> char {

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -61,7 +61,7 @@ pub enum MathStyle {
 
 /// Converts a [`char`] to the styled form specified by `style`.
 ///
-/// Note that some styles will convert a charater into multiple characters,
+/// Note that some styles will convert a character into multiple characters,
 /// hence this function always returns an array of two characters.
 ///
 /// # Examples
@@ -110,7 +110,8 @@ pub trait MathStyling {
     /// Converts each [`char`] in the given value to the styled form given by
     /// `style`.
     ///
-    /// Note that some styles will convert a charater into multiple characters.
+    /// Note that some styles will convert a character into multiple
+    /// characters.
     ///
     /// # Examples
     ///
@@ -155,6 +156,7 @@ impl MathStyling for String {
 /// Functions which map a [`char`] to its specified styled form.
 ///
 /// Sourced from:
+/// - [Unicode Core Specification]
 /// - [Mathematical Alphanumeric Symbols]
 /// - [Arabic Mathematical Alphabetic Symbols]
 /// - <https://www.w3.org/TR/mathml-core/#new-text-transform-mappings>
@@ -170,6 +172,7 @@ impl MathStyling for String {
 /// assert_eq!(['𝒫', '\u{FE01}'], to_roundhand('P'));
 /// ```
 ///
+/// [Unicode Core Specification]: <https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-22/#G16021>
 /// [Mathematical Alphanumeric Symbols]: <https://unicode.org/charts/PDF/U1D400.pdf>
 /// [Arabic Mathematical Alphabetic Symbols]: <https://unicode.org/charts/PDF/U1EE00.pdf>
 pub mod mappings {
@@ -402,9 +405,9 @@ pub mod mappings {
     ///
     /// This function returns a variation sequence using the variation selector
     /// `U+FE00`, as specified in the [`StandardizedVariants.txt`] file from
-    /// the Unicode Character Database. Note that only the capital latin
+    /// the Unicode Character Database. Note that only the capital Latin
     /// letters are standardized variation sequences, but this function also
-    /// maps the small latin letters.
+    /// maps the small Latin letters.
     ///
     /// [`StandardizedVariants.txt`]: <https://www.unicode.org/Public/UNIDATA/StandardizedVariants.txt>
     pub fn to_chancery(c: char) -> [char; 2] {
@@ -424,9 +427,9 @@ pub mod mappings {
     ///
     /// This function returns a variation sequence using the variation selector
     /// `U+FE01`, as specified in the [`StandardizedVariants.txt`] file from
-    /// the Unicode Character Database. Note that only the capital latin
+    /// the Unicode Character Database. Note that only the capital Latin
     /// letters are standardized variation sequences, but this function also
-    /// maps the small latin letters.
+    /// maps the small Latin letters.
     ///
     /// [`StandardizedVariants.txt`]: <https://www.unicode.org/Public/UNIDATA/StandardizedVariants.txt>
     pub fn to_roundhand(c: char) -> [char; 2] {
@@ -488,7 +491,7 @@ pub mod mappings {
 
     /// To double-struck italic symbols.
     ///
-    /// Note that there does not exit codepoints in Unicode for all Latin
+    /// Note that there does not exist codepoints in Unicode for all Latin
     /// letters. There are only a few double-struck italic symbols, and they
     /// are present solely in the Letterlike Symbols block.
     pub fn to_double_struck_italic(c: char) -> char {

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -72,11 +72,11 @@ pub enum MathStyle {
     ///
     /// Supported characters: latin, greek.
     BoldItalic,
-    /// Script style.
+    /// Script style. May be chancery or roundhand depending on the font.
     ///
     /// Supported characters: latin.
     Script,
-    /// Bold script style.
+    /// Bold script style. May be chancery or roundhand depending on the font.
     ///
     /// Supported characters: latin.
     BoldScript,

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -1,0 +1,613 @@
+/*!
+Style mathematical symbols in Unicode.
+*/
+
+/// A styled form for mathematical symbols.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub enum MathStyle {
+    /// Normal style and isolated style (for Arabic). May be serif or
+    /// sans-serif depending upon the font.
+    ///
+    /// This is the default.
+    #[default]
+    Serif,
+    /// Normal bold style. May be serif or sans-serif depending upon the font.
+    SerifBold,
+    /// Normal italic style. May be serif or sans-serif depending upon the
+    /// font.
+    SerifItalic,
+    /// Normal bold italic style. May be serif or sans-serif depending upon the
+    /// font.
+    SerifItalicBold,
+    /// Sans-serif style.
+    SansSerif,
+    /// Sans-serif bold style.
+    SansSerifBold,
+    /// Sans-serif italic style.
+    SansSerifItalic,
+    /// Sans-serif bold italic style.
+    SansSerifItalicBold,
+    /// Fraktur style. Also known as black-letter.
+    Fraktur,
+    /// Bold fraktur style.
+    FrakturBold,
+    /// Script style.
+    Script,
+    /// Bold script style.
+    ScriptBold,
+    /// Chancery variant of script style.
+    Chancery,
+    /// Chancery variant of bold script style.
+    ChanceryBold,
+    /// Roundhand variant of script style.
+    Roundhand,
+    /// Roundhand variant of bold script style.
+    RoundhandBold,
+    /// Double-struck style. Also known as open-face or blackboard-bold.
+    DoubleStruck,
+    /// Double-struck italic style.
+    DoubleStruckItalic,
+    /// Monospace style.
+    Monospace,
+    /// Initial style (for Arabic).
+    Initial,
+    /// Tailed style (for Arabic).
+    Tailed,
+    /// Looped style (for Arabic).
+    Looped,
+    /// Stretched style (for Arabic).
+    Stretched,
+}
+
+/// Converts a [`char`] to the styled form specified by `style`.
+///
+/// Note that some styles will convert a charater into multiple characters,
+/// hence this function always returns an array of two characters.
+///
+/// # Examples
+///
+/// ```
+/// use codex::styling::{to_style, MathStyle};
+///
+/// assert_eq!(['𝑴', '\0'], to_style('M', MathStyle::SerifItalicBold));
+/// assert_eq!(['𞸪', '\0'], to_style('ك', MathStyle::Initial));
+/// assert_eq!(['ⅈ', '\0'], to_style('i', MathStyle::DoubleStruckItalic));
+/// assert_eq!(['𝓴', '\u{fe01}'], to_style('k', MathStyle::RoundhandBold));
+/// ```
+pub fn to_style(c: char, style: MathStyle) -> [char; 2] {
+    use mappings::*;
+    use MathStyle::*;
+    match style {
+        Serif => [to_serif(c), '\0'],
+        SerifBold => [to_serif_bold(c), '\0'],
+        SerifItalic => [to_serif_italic(c), '\0'],
+        SerifItalicBold => [to_serif_italic_bold(c), '\0'],
+        SansSerif => [to_sans_serif(c), '\0'],
+        SansSerifBold => [to_sans_serif_bold(c), '\0'],
+        SansSerifItalic => [to_sans_serif_italic(c), '\0'],
+        SansSerifItalicBold => [to_sans_serif_italic_bold(c), '\0'],
+        Fraktur => [to_fraktur(c), '\0'],
+        FrakturBold => [to_fraktur_bold(c), '\0'],
+        Script => [to_script(c), '\0'],
+        ScriptBold => [to_script_bold(c), '\0'],
+        Chancery => to_chancery(c),
+        ChanceryBold => to_chancery_bold(c),
+        Roundhand => to_roundhand(c),
+        RoundhandBold => to_roundhand_bold(c),
+        DoubleStruck => [to_double_struck(c), '\0'],
+        DoubleStruckItalic => [to_double_struck_italic(c), '\0'],
+        Monospace => [to_monospace(c), '\0'],
+        Initial => [to_initial(c), '\0'],
+        Tailed => [to_tailed(c), '\0'],
+        Looped => [to_looped(c), '\0'],
+        Stretched => [to_stretched(c), '\0'],
+    }
+}
+
+/// A trait for converting each [`char`] in a value to its specified styled
+/// form.
+pub trait MathStyling {
+    /// Converts each [`char`] in the given value to the styled form given by
+    /// `style`.
+    ///
+    /// Note that some styles will convert a charater into multiple characters.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use codex::styling::{MathStyle, MathStyling};
+    ///
+    /// let s = String::from("mono");
+    ///
+    /// assert_eq!("𝚖𝚘𝚗𝚘", s.to_style(MathStyle::Monospace));
+    /// ```
+    ///
+    /// One character can become multiple:
+    ///
+    /// ```
+    /// # use codex::styling::{MathStyle, MathStyling};
+    /// let s = String::from("foo");
+    ///
+    /// assert_eq!("𝒻\u{fe00}ℴ\u{fe00}ℴ\u{fe00}", s.to_style(MathStyle::Chancery));
+    /// ```
+    fn to_style(&self, style: MathStyle) -> Self;
+}
+
+impl MathStyling for String {
+    fn to_style(&self, style: MathStyle) -> Self {
+        let str = self.as_str();
+        let mut styled = Self::with_capacity(str.len());
+        for c in str.chars() {
+            match to_style(c, style) {
+                [a, '\0'] => styled.push(a),
+                [a, b] => {
+                    styled.push(a);
+                    styled.push(b);
+                }
+            }
+        }
+        styled
+    }
+}
+
+/// Functions which map a [`char`] to its specified styled form.
+///
+/// Sourced from:
+/// - [Mathematical Alphanumeric Symbols]
+/// - [Arabic Mathematical Alphabetic Symbols]
+/// - <https://www.w3.org/TR/mathml-core/#new-text-transform-mappings>
+///
+/// ## Examples
+///
+/// ```
+/// use codex::styling::mappings::*;
+///
+/// assert_eq!('𝔭', to_fraktur('p'));
+/// assert_eq!('𝞌', to_sans_serif_bold('ϰ'));
+/// assert_eq!('𞺰', to_double_struck('ف'));
+/// assert_eq!(['𝒫', '\u{FE01}'], to_roundhand('P'));
+/// ```
+///
+/// [Mathematical Alphanumeric Symbols]: <https://unicode.org/charts/PDF/U1D400.pdf>
+/// [Arabic Mathematical Alphabetic Symbols]: <https://unicode.org/charts/PDF/U1EE00.pdf>
+pub mod mappings {
+    const VARIATION_SELECTOR_1: char = '\u{FE00}';
+    const VARIATION_SELECTOR_2: char = '\u{FE01}';
+
+    /// The character given by adding `delta` to the codepoint of `c`.
+    #[inline]
+    fn apply_delta(c: char, delta: u32) -> char {
+        std::char::from_u32((c as u32) + delta).unwrap()
+    }
+
+    /// To normal and isolated symbols.
+    ///
+    /// This is the normal unstyled form, and may be serif or sans-serif
+    /// depending upon the font.
+    ///
+    /// This is also the isolated style, the normal form for Arabic.
+    pub fn to_serif(c: char) -> char {
+        c
+    }
+
+    /// To bold symbols.
+    ///
+    /// This is the normal bold form, and may be serif or sans-serif depending
+    /// upon the font.
+    pub fn to_serif_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D3BF,
+            'a'..='z' => 0x1D3B9,
+            'Α'..='Ρ' => 0x1D317,
+            'ϴ' => 0x1D2C5,
+            'Σ'..='Ω' => 0x1D317,
+            '∇' => 0x1B4BA,
+            'α'..='ω' => 0x1D311,
+            '∂' => 0x1B4D9,
+            'ϵ' => 0x1D2E7,
+            'ϑ' => 0x1D30C,
+            'ϰ' => 0x1D2EE,
+            'ϕ' => 0x1D30A,
+            'ϱ' => 0x1D2EF,
+            'ϖ' => 0x1D30B,
+            'Ϝ' | 'ϝ' => 0x1D3EE,
+            '0'..='9' => 0x1D79E,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To italic symbols.
+    ///
+    /// This is the normal italic form, and may be serif or sans-serif
+    /// depending upon the font.
+    pub fn to_serif_italic(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D3F3,
+            'h' => 0x20A6,
+            'a'..='z' => 0x1D3ED,
+            'ı' => 0x1D573,
+            'ȷ' => 0x1D46E,
+            'Α'..='Ρ' => 0x1D351,
+            'ϴ' => 0x1D2FF,
+            'Σ'..='Ω' => 0x1D351,
+            '∇' => 0x1B4F4,
+            'α'..='ω' => 0x1D34B,
+            '∂' => 0x1B513,
+            'ϵ' => 0x1D321,
+            'ϑ' => 0x1D346,
+            'ϰ' => 0x1D328,
+            'ϕ' => 0x1D344,
+            'ϱ' => 0x1D329,
+            'ϖ' => 0x1D345,
+            // Missing from MathML Core.
+            'ħ' => 0x1FE8,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To bold italic symbols.
+    ///
+    /// This is the normal bold italic form, and may be serif or sans-serif
+    /// depending upon the font.
+    pub fn to_serif_italic_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D427,
+            'a'..='z' => 0x1D421,
+            'Α'..='Ρ' => 0x1D38B,
+            'ϴ' => 0x1D339,
+            'Σ'..='Ω' => 0x1D38B,
+            '∇' => 0x1B52E,
+            'α'..='ω' => 0x1D385,
+            '∂' => 0x1B54D,
+            'ϵ' => 0x1D35B,
+            'ϑ' => 0x1D380,
+            'ϰ' => 0x1D362,
+            'ϕ' => 0x1D37E,
+            'ϱ' => 0x1D363,
+            'ϖ' => 0x1D37F,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To sans-serif symbols.
+    pub fn to_sans_serif(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D55F,
+            'a'..='z' => 0x1D559,
+            '0'..='9' => 0x1D7B2,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To sans-serif bold symbols.
+    pub fn to_sans_serif_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D593,
+            'a'..='z' => 0x1D58D,
+            'Α'..='Ρ' => 0x1D3C5,
+            'ϴ' => 0x1D373,
+            'Σ'..='Ω' => 0x1D3C5,
+            '∇' => 0x1B568,
+            'α'..='ω' => 0x1D3BF,
+            '∂' => 0x1B587,
+            'ϵ' => 0x1D395,
+            'ϑ' => 0x1D3BA,
+            'ϰ' => 0x1D39C,
+            'ϕ' => 0x1D3B8,
+            'ϱ' => 0x1D39D,
+            'ϖ' => 0x1D3B9,
+            '0'..='9' => 0x1D7BC,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To sans-serif italic symbols.
+    pub fn to_sans_serif_italic(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D5C7,
+            'a'..='z' => 0x1D5C1,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To sans-serif bold italic symbols.
+    pub fn to_sans_serif_italic_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D593,
+            'a'..='z' => 0x1D58D,
+            'Α'..='Ρ' => 0x1D3C5,
+            'ϴ' => 0x1D373,
+            'Σ'..='Ω' => 0x1D3C5,
+            '∇' => 0x1B568,
+            'α'..='ω' => 0x1D3BF,
+            '∂' => 0x1B587,
+            'ϵ' => 0x1D395,
+            'ϑ' => 0x1D3BA,
+            'ϰ' => 0x1D39C,
+            'ϕ' => 0x1D3B8,
+            'ϱ' => 0x1D39D,
+            'ϖ' => 0x1D3B9,
+            '0'..='9' => 0x1D7BC,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To fraktur symbols.
+    ///
+    /// This style is sometimes known as black-letter.
+    pub fn to_fraktur(c: char) -> char {
+        let delta = match c {
+            'C' => 0x20EA,
+            'H' => 0x20C4,
+            'I' => 0x20C8,
+            'R' => 0x20CA,
+            'Z' => 0x20CE,
+            'A'..='Z' => 0x1D4C3,
+            'a'..='z' => 0x1D4BD,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To bold fraktur symbols.
+    pub fn to_fraktur_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D52B,
+            'a'..='z' => 0x1D525,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To script symbols.
+    pub fn to_script(c: char) -> char {
+        let delta = match c {
+            'B' => 0x20EA,
+            'E'..='F' => 0x20EB,
+            'H' => 0x20C3,
+            'I' => 0x20C7,
+            'L' => 0x20C6,
+            'M' => 0x20E6,
+            'R' => 0x20C9,
+            'A'..='Z' => 0x1D45B,
+            'e' => 0x20CA,
+            'g' => 0x20A3,
+            'o' => 0x20C5,
+            'a'..='z' => 0x1D455,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To bold script symbols.
+    pub fn to_script_bold(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D48F,
+            'a'..='z' => 0x1D489,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To chancery style of script symbols.
+    ///
+    /// This function returns a variation sequence using the variation selector
+    /// `U+FE00`, as specified in the [`StandardizedVariants.txt`] file from
+    /// the Unicode Character Database. Note that only the capital latin
+    /// letters are standardized variation sequences, but this function also
+    /// maps the small latin letters.
+    ///
+    /// [`StandardizedVariants.txt`]: <https://www.unicode.org/Public/UNIDATA/StandardizedVariants.txt>
+    pub fn to_chancery(c: char) -> [char; 2] {
+        [to_script(c), VARIATION_SELECTOR_1]
+    }
+
+    /// To chancery style of bold script symbols.
+    ///
+    /// This function returns a variation sequence using the variation selector
+    /// `U+FE00`. Note however that the bold script symbols are _not_ specified
+    /// as standardized variation sequences by Unicode.
+    pub fn to_chancery_bold(c: char) -> [char; 2] {
+        [to_script_bold(c), VARIATION_SELECTOR_1]
+    }
+
+    /// To roundhand style of script symbols.
+    ///
+    /// This function returns a variation sequence using the variation selector
+    /// `U+FE01`, as specified in the [`StandardizedVariants.txt`] file from
+    /// the Unicode Character Database. Note that only the capital latin
+    /// letters are standardized variation sequences, but this function also
+    /// maps the small latin letters.
+    ///
+    /// [`StandardizedVariants.txt`]: <https://www.unicode.org/Public/UNIDATA/StandardizedVariants.txt>
+    pub fn to_roundhand(c: char) -> [char; 2] {
+        [to_script(c), VARIATION_SELECTOR_2]
+    }
+
+    /// To roundhand style of bold script symbols.
+    ///
+    /// This function returns a variation sequence using the variation selector
+    /// `U+FE01`. Note however that the bold script symbols are _not_ specified
+    /// as standardized variation sequences by Unicode.
+    pub fn to_roundhand_bold(c: char) -> [char; 2] {
+        [to_script_bold(c), VARIATION_SELECTOR_2]
+    }
+
+    /// To double-struck symbols.
+    ///
+    /// This style is sometimes known as open-face or blackboard-bold.
+    pub fn to_double_struck(c: char) -> char {
+        let delta = match c {
+            'C' => 0x20BF,
+            'H' => 0x20C5,
+            'N' => 0x20C7,
+            'P'..='Q' => 0x20C9,
+            'R' => 0x20CB,
+            'Z' => 0x20CA,
+            'A'..='Z' => 0x1D4F7,
+            'a'..='z' => 0x1D4F1,
+            '0'..='9' => 0x1D7A8,
+            'ب' => 0x1E879,
+            'ج' | 'ع' => 0x1E876,
+            'د' | 'ز' => 0x1E874,
+            'و' => 0x1E85D,
+            'ح' => 0x1E87A,
+            'ط' => 0x1E871,
+            'ي' => 0x1E85F,
+            'ل'..='ن' => 0x1E867,
+            'س' => 0x1E87B,
+            'ف' => 0x1E86F,
+            'ص' => 0x1E87C,
+            'ق' => 0x1E870,
+            'ر' | 'ظ' => 0x1E882,
+            'ش' => 0x1E880,
+            'ت'..='ث' => 0x1E88B,
+            'خ' => 0x1E889,
+            'ذ' => 0x1E888,
+            'ض' => 0x1E883,
+            'غ' => 0x1E881,
+            // Missing from MathML Core.
+            'Γ' => 0x1DAB,
+            'Π' => 0x1D9F,
+            'γ' => 0x1D8A,
+            'π' => 0x1D7C,
+            '∑' => return '⅀', // Delta is negative.
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To double-struck italic symbols.
+    ///
+    /// Note that there does not exit codepoints in Unicode for all Latin
+    /// letters. There are only a few double-struck italic symbols, and they
+    /// are present solely in the Letterlike Symbols block.
+    pub fn to_double_struck_italic(c: char) -> char {
+        let delta = match c {
+            // Missing from MathML Core.
+            'D' => 0x2101,
+            'd'..='e' => 0x20E2,
+            'i'..='j' => 0x20DF,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To monospace symbols.
+    pub fn to_monospace(c: char) -> char {
+        let delta = match c {
+            'A'..='Z' => 0x1D62F,
+            'a'..='z' => 0x1D629,
+            '0'..='9' => 0x1D7C6,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To initial symbols.
+    pub fn to_initial(c: char) -> char {
+        let delta = match c {
+            'ب' => 0x1E7F9,
+            'ج' | 'ع' => 0x1E7F6,
+            'ه' => 0x1E7DD,
+            'ح' => 0x1E7FA,
+            'ي' => 0x1E7DF,
+            'ك'..='ن' => 0x1E7E7,
+            'س' => 0x1E7FB,
+            'ف' => 0x1E7EF,
+            'ص' => 0x1E7FC,
+            'ق' => 0x1E7F0,
+            'ش' => 0x1E800,
+            'ت'..='ث' => 0x1E80B,
+            'خ' => 0x1E809,
+            'ض' => 0x1E803,
+            'غ' => 0x1E801,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To tailed symbols.
+    pub fn to_tailed(c: char) -> char {
+        let delta = match c {
+            'ج' | 'ع' => 0x1E816,
+            'ح' => 0x1E81A,
+            'ي' => 0x1E7FF,
+            'ل' | 'ن' => 0x1E807,
+            'س' => 0x1E81B,
+            'ص' => 0x1E81C,
+            'ق' => 0x1E810,
+            'ش' => 0x1E820,
+            'خ' => 0x1E829,
+            'ض' => 0x1E823,
+            'غ' => 0x1E821,
+            'ں' => 0x1E7A3,
+            'ٯ' => 0x1E7F0,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To stretched symbols.
+    pub fn to_stretched(c: char) -> char {
+        let delta = match c {
+            'ب' => 0x1E839,
+            'ج' | 'ع' => 0x1E836,
+            'ه' => 0x1E81D,
+            'ح' => 0x1E83A,
+            'ط' => 0x1E831,
+            'ي' => 0x1E81F,
+            'ك' | 'م'..='ن' => 0x1E827,
+            'س' => 0x1E83B,
+            'ف' => 0x1E82F,
+            'ص' => 0x1E83C,
+            'ق' => 0x1E830,
+            'ش' => 0x1E840,
+            'ت'..='ث' => 0x1E84B,
+            'خ' => 0x1E849,
+            'ض' => 0x1E843,
+            'ظ' => 0x1E842,
+            'غ' => 0x1E841,
+            'ٮ' => 0x1E80E,
+            'ڡ' => 0x1E7DD,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+
+    /// To looped symbols.
+    pub fn to_looped(c: char) -> char {
+        let delta = match c {
+            'ا'..='ب' => 0x1E859,
+            'ج' | 'ع' => 0x1E856,
+            'د' | 'ز' => 0x1E854,
+            'ه'..='و' => 0x1E83D,
+            'ح' => 0x1E85A,
+            'ط' => 0x1E851,
+            'ي' => 0x1E83F,
+            'ل'..='ن' => 0x1E847,
+            'س' => 0x1E85B,
+            'ف' => 0x1E84F,
+            'ص' => 0x1E85C,
+            'ق' => 0x1E850,
+            'ر' | 'ظ' => 0x1E862,
+            'ش' => 0x1E860,
+            'ت'..='ث' => 0x1E86B,
+            'خ' => 0x1E869,
+            'ذ' => 0x1E868,
+            'ض' => 0x1E863,
+            'غ' => 0x1E861,
+            _ => return c,
+        };
+        apply_delta(c, delta)
+    }
+}

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -1,6 +1,4 @@
-/*!
-Style mathematical symbols in Unicode.
-*/
+//! Style mathematical symbols in Unicode.
 
 /// A styled form for mathematical symbols.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -91,19 +91,19 @@ pub enum MathStyle {
     /// Sans-serif style.
     ///
     /// Supported characters: digits, latin.
-    Sansserif,
+    SansSerif,
     /// Bold sans-serif style.
     ///
     /// Supported characters: digits, latin, greek.
-    SansserifBold,
+    SansSerifBold,
     /// Italic sans-serif style.
     ///
     /// Supported characters: latin.
-    SansserifItalic,
+    SansSerifItalic,
     /// Bold italic sans-serif style.
     ///
     /// Supported characters: latin, greek.
-    SansserifBoldItalic,
+    SansSerifBoldItalic,
     /// Monospace style.
     ///
     /// Supported characters: digits, latin.
@@ -270,10 +270,10 @@ pub fn to_style(c: char, style: MathStyle) -> ToStyle {
         BoldScript => [to_bold_script(c), '\0'],
         Fraktur => [to_fraktur(c), '\0'],
         BoldFraktur => [to_bold_fraktur(c), '\0'],
-        Sansserif => [to_sansserif(c), '\0'],
-        SansserifBold => [to_sansserif_bold(c), '\0'],
-        SansserifItalic => [to_sansserif_italic(c), '\0'],
-        SansserifBoldItalic => [to_sansserif_bold_italic(c), '\0'],
+        SansSerif => [to_sans_serif(c), '\0'],
+        SansSerifBold => [to_sans_serif_bold(c), '\0'],
+        SansSerifItalic => [to_sans_serif_italic(c), '\0'],
+        SansSerifBoldItalic => [to_sans_serif_bold_italic(c), '\0'],
         Monospace => [to_monospace(c), '\0'],
         Isolated => [to_isolated(c), '\0'],
         Initial => [to_initial(c), '\0'],
@@ -464,7 +464,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_sansserif(c: char) -> char {
+    pub fn to_sans_serif(c: char) -> char {
         let delta = match c {
             // Mathematical Alphanumeric Symbols Block (U+1D400..U+1D7FF)
             // Sans-serif symbols (U+1D5A0..U+1D5D3)
@@ -477,7 +477,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_sansserif_bold(c: char) -> char {
+    pub fn to_sans_serif_bold(c: char) -> char {
         let delta = match c {
             // Mathematical Alphanumeric Symbols Block (U+1D400..U+1D7FF)
             // Sans-serif bold symbols (U+1D5D4..U+1D607)
@@ -504,7 +504,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_sansserif_italic(c: char) -> char {
+    pub fn to_sans_serif_italic(c: char) -> char {
         let delta = match c {
             // Mathematical Alphanumeric Symbols Block (U+1D400..U+1D7FF)
             // Sans-serif italic symbols (U+1D608..U+1D63B)
@@ -515,7 +515,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_sansserif_bold_italic(c: char) -> char {
+    pub fn to_sans_serif_bold_italic(c: char) -> char {
         let delta = match c {
             // Mathematical Alphanumeric Symbols Block (U+1D400..U+1D7FF)
             // Sans-serif bold italic symbols (U+1D63C..U+1D66F)

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -60,54 +60,6 @@ pub enum MathStyle {
     Stretched,
 }
 
-impl MathStyle {
-    /// Applies the style to a given `char`.
-    ///
-    /// Note that some styles will convert a character into multiple
-    /// characters, hence this function always returns an array of two
-    /// characters.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use codex::styling::MathStyle;
-    ///
-    /// assert_eq!(['𝑴', '\0'], MathStyle::SerifItalicBold.apply('M'));
-    /// assert_eq!(['𞸪', '\0'], MathStyle::Initial.apply('ك'));
-    /// assert_eq!(['ⅈ', '\0'], MathStyle::DoubleStruckItalic.apply('i'));
-    /// assert_eq!(['𝓴', '\u{fe01}'], MathStyle::RoundhandBold.apply('k'));
-    /// ```
-    pub fn apply(self, c: char) -> [char; 2] {
-        use mappings::*;
-        use MathStyle::*;
-        match self {
-            Serif => [to_serif(c), '\0'],
-            SerifBold => [to_serif_bold(c), '\0'],
-            SerifItalic => [to_serif_italic(c), '\0'],
-            SerifItalicBold => [to_serif_italic_bold(c), '\0'],
-            SansSerif => [to_sans_serif(c), '\0'],
-            SansSerifBold => [to_sans_serif_bold(c), '\0'],
-            SansSerifItalic => [to_sans_serif_italic(c), '\0'],
-            SansSerifItalicBold => [to_sans_serif_italic_bold(c), '\0'],
-            Fraktur => [to_fraktur(c), '\0'],
-            FrakturBold => [to_fraktur_bold(c), '\0'],
-            Script => [to_script(c), '\0'],
-            ScriptBold => [to_script_bold(c), '\0'],
-            Chancery => to_chancery(c),
-            ChanceryBold => to_chancery_bold(c),
-            Roundhand => to_roundhand(c),
-            RoundhandBold => to_roundhand_bold(c),
-            DoubleStruck => [to_double_struck(c), '\0'],
-            DoubleStruckItalic => [to_double_struck_italic(c), '\0'],
-            Monospace => [to_monospace(c), '\0'],
-            Initial => [to_initial(c), '\0'],
-            Tailed => [to_tailed(c), '\0'],
-            Looped => [to_looped(c), '\0'],
-            Stretched => [to_stretched(c), '\0'],
-        }
-    }
-}
-
 /// Returns an iterator that yields the styled equivalent of a `char`.
 ///
 /// This `struct` is created by the [`to_style`] function. See its
@@ -201,9 +153,35 @@ impl fmt::Display for ToStyle {
 ///     .collect::<String>();
 /// assert_eq!("𝕩ℽΩ𝔸𞺸𞺧𝟙⅀𞺮", s);
 /// ```
-#[inline]
 pub fn to_style(c: char, style: MathStyle) -> ToStyle {
-    ToStyle::new(style.apply(c))
+    use mappings::*;
+    use MathStyle::*;
+    let styled = match style {
+        Serif => [to_serif(c), '\0'],
+        SerifBold => [to_serif_bold(c), '\0'],
+        SerifItalic => [to_serif_italic(c), '\0'],
+        SerifItalicBold => [to_serif_italic_bold(c), '\0'],
+        SansSerif => [to_sans_serif(c), '\0'],
+        SansSerifBold => [to_sans_serif_bold(c), '\0'],
+        SansSerifItalic => [to_sans_serif_italic(c), '\0'],
+        SansSerifItalicBold => [to_sans_serif_italic_bold(c), '\0'],
+        Fraktur => [to_fraktur(c), '\0'],
+        FrakturBold => [to_fraktur_bold(c), '\0'],
+        Script => [to_script(c), '\0'],
+        ScriptBold => [to_script_bold(c), '\0'],
+        Chancery => to_chancery(c),
+        ChanceryBold => to_chancery_bold(c),
+        Roundhand => to_roundhand(c),
+        RoundhandBold => to_roundhand_bold(c),
+        DoubleStruck => [to_double_struck(c), '\0'],
+        DoubleStruckItalic => [to_double_struck_italic(c), '\0'],
+        Monospace => [to_monospace(c), '\0'],
+        Initial => [to_initial(c), '\0'],
+        Tailed => [to_tailed(c), '\0'],
+        Looped => [to_looped(c), '\0'],
+        Stretched => [to_stretched(c), '\0'],
+    };
+    ToStyle::new(styled)
 }
 
 /// Functions which map a `char` to its specified styled form.

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -170,7 +170,6 @@ pub enum MathStyle {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum MathVariant {
     Plain,
-    Script,
     Fraktur,
     SansSerif,
     Monospace,
@@ -237,8 +236,6 @@ impl MathStyle {
             (SansSerif, _, Some(true)) if is_greek(c) => MathStyle::SansSerifBoldItalic,
             (SansSerif, _, None) if is_upper_greek(c) => MathStyle::SansSerifBold,
             (SansSerif, _, None) if is_lower_greek(c) => MathStyle::SansSerifBoldItalic,
-            (Script, false, _) if is_latin(c) => MathStyle::Script,
-            (Script, true, _) if is_latin(c) => MathStyle::BoldScript,
             (Fraktur, false, _) if is_latin(c) => MathStyle::Fraktur,
             (Fraktur, true, _) if is_latin(c) => MathStyle::BoldFraktur,
             (Monospace, _, _) if is_digit(c) | is_latin(c) => MathStyle::Monospace,

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -50,7 +50,7 @@ pub const UNICODE_VERSION: (u8, u8, u8) = (16, 0, 0);
 /// # Shaping
 ///
 /// The Arabic styles (including those from the
-/// [`Doublestruck`](MathStyle::Doublestruck) style) are not subject to
+/// [`DoubleStruck`](MathStyle::DoubleStruck) style) are not subject to
 /// shaping. However, [`Plain`](MathStyle::Plain) should still be shaped, as
 /// the characters are Arabic letters in the Arabic block (U+0600..U+06FF).
 ///
@@ -140,13 +140,13 @@ pub enum MathStyle {
     /// Supported characters: digits, latin, arabic excluding ا (U+0627),
     /// ك (U+0643), ه (U+0647), and the extras ∑ (U+2211), Γ (U+0393), Π
     /// (U+03A0), γ (U+03B3), π (U+03C0).
-    Doublestruck,
+    DoubleStruck,
     /// Italic double-struck style. Also known as italic open-face style or
     /// italic blackboard-bold style.
     ///
     /// This is an exceptional style as only the following Latin letters are
     /// supported: D (U+0044), d (U+0064), e (U+0065), i (U+0069), j (U+006A).
-    DoublestruckItalic,
+    DoubleStruckItalic,
     /// Chancery variant of script style.
     ///
     /// Supported characters: latin.
@@ -254,7 +254,7 @@ impl fmt::Display for ToStyle {
 ///
 /// let s = "xγΩAذح1∑س"
 ///     .chars()
-///     .flat_map(|c| to_style(c, MathStyle::Doublestruck))
+///     .flat_map(|c| to_style(c, MathStyle::DoubleStruck))
 ///     .collect::<String>();
 /// assert_eq!("𝕩ℽΩ𝔸𞺸𞺧𝟙⅀𞺮", s);
 /// ```
@@ -280,8 +280,8 @@ pub fn to_style(c: char, style: MathStyle) -> ToStyle {
         Tailed => [to_tailed(c), '\0'],
         Stretched => [to_stretched(c), '\0'],
         Looped => [to_looped(c), '\0'],
-        Doublestruck => [to_doublestruck(c), '\0'],
-        DoublestruckItalic => [to_doublestruck_italic(c), '\0'],
+        DoubleStruck => [to_double_struck(c), '\0'],
+        DoubleStruckItalic => [to_double_struck_italic(c), '\0'],
         Chancery => to_chancery(c),
         BoldChancery => to_bold_chancery(c),
         Roundhand => to_roundhand(c),
@@ -698,7 +698,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_doublestruck(c: char) -> char {
+    pub fn to_double_struck(c: char) -> char {
         let delta = match c {
             // Letterlike Symbols Block (U+2100..U+214F)
             // Letterlike symbols (U+2100..U+2134)
@@ -752,7 +752,7 @@ mod conversions {
         apply_delta(c, delta)
     }
 
-    pub fn to_doublestruck_italic(c: char) -> char {
+    pub fn to_double_struck_italic(c: char) -> char {
         let delta = match c {
             // Letterlike Symbols Block (U+2100..U+214F)
             // Double-struck italic math symbols (U+2145..U+2149)


### PR DESCRIPTION
This PR adds functions and the related infrastructure needed to take a character/string and a style in math (e.g. blackboard-bold, monospace), and return it in styled form. It is implemented under the feature `styling`, which I've added as a default.

Moving this to Codex was brought up briefly on Discord, and whilst it doesn't directly fall under "naming Unicode symbols", I think it still fits quite nicely in this crate. I may have jumped the gun a little on this, but it wasn't much work to do. Hopefully this PR starts some more thorough discussion of this idea. I also think that moving this outside of the main typst repo will be an improvement and make it more maintainable.