### PR TITLE
Make `planck` more useful (Proposal 26)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1025,8 +1025,7 @@ ZZ ℤ
 
 // Miscellaneous letter-likes.
 ell ℓ
-planck ℎ
-  .reduce ℏ
+planck ħ
 angstrom Å
 kelvin K
 Re ℜ


### PR DESCRIPTION
## Description

This PR implements Proposal 26 (iteration 1) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It changes `planck` to ħ (which gets italicized to ℏ in math thanks to https://github.com/typst/typst/pull/5492), and removes the `planck.reduce` variant. For more context, see [the discussion on Discord](https://discord.com/channels/1054443721975922748/1277628305142452306/1325065616444624956).

There is no way to take advantage of the symbol deprecation mechanism introduced in #19 to make this change smoother.

## Breaking changes (cc. @laurmaedje)

`planck.reduce` becomes invalid, and `planck` changes codepoint.