### PR TITLE
Symbol Aliases

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -193,7 +193,7 @@ breve ˘
 caret ‸
 caron ˇ
 hat ^
-diaer ¨
+@diaer dot.double
 grave `
 macron ¯
 quote
@@ -359,8 +359,7 @@ succ ≻
   .not ⊁
   .ntilde ⋩
   .tilde ≿
-equiv ≡
-  .not ≢
+@equiv eq.triple.*
 smt ⪪
   .eq ⪬
 lat ⪫
@@ -378,12 +377,7 @@ emptyset ∅
   .bar ⦱
   .circle ⦲
   .rev ⦰
-nothing ∅
-  .arrow.r ⦳
-  .arrow.l ⦴
-  .bar ⦱
-  .circle ⦲
-  .rev ⦰
+@nothing emptyset.*
 without ∖
 complement ∁
 in ∈
@@ -441,10 +435,10 @@ infinity ∞
   .bar ⧞
   .incomplete ⧜
   .tie ⧝
-oo ∞
+@oo infinity
 partial ∂
 gradient ∇
-nabla ∇
+@nabla gradient.*
 sum ∑
   .integral ⨋
 product ∏
@@ -474,8 +468,8 @@ laplace ∆
 forall ∀
 exists ∃
   .not ∄
-top ⊤
-bot ⊥
+@top tack.b
+@bot tack.t
 not ¬
 and ∧
   .big ⋀
@@ -487,8 +481,7 @@ or ∨
   .curly ⋎
   .dot ⟇
   .double ⩔
-xor ⊕
-  .big ⨁
+@xor plus.circle.*
 models ⊧
 forces ⊩
   .not ⊮
@@ -497,8 +490,8 @@ because ∵
 qed ∎
 
 // Function and category theory.
-compose ∘
-convolve ∗
+@compose circle.stroked.tiny
+@convolve ast.op
 multimap ⊸
   .double ⧟
 
@@ -987,13 +980,13 @@ Zeta Ζ
 // from Letterlike Symbols.
 // See https://github.com/typst/typst/pull/3375.
 aleph א
-alef א
+@alef aleph
 beth ב
-bet ב
+@bet beth
 gimmel ג
-gimel ג
+@gimel gimmel
 daleth ד
-dalet ד
+@dalet daleth
 shin ש
 
 // Double-struck.


### PR DESCRIPTION
This PR implements a new framework for defining aliases, i.e. symbols that copy other symbols, and uses that for all of the previously duplicated symbols in `sym`.

We don't intend to have a lot of these, but for the ones we do have, having a system like this is a big improvement to maintainability.
As a good illustration, this PR automatically adds the `arrow` variant from `plus.circle` to `xor`, which seems to have previously been overlooked.

## Guide to creating Aliases
There are two types of aliases:
- Shallow aliases copy a symbol/variant without any other variants. This is the equivalent of `let alias = symbol(a.b.c)` in typst.
- Deep aliases copy a symbol, possibly with some pre-applied modifiers, and all further modifiers. This is the equivalent of `let alias = a.b.c` in typst.

A shallow alias is declared with
```
@<alias> <other symbol name, possibly with modifiers>
```
A deep alias is the same, but additionally ends with `.*`.
Note that this isn't quite like a glob pattern, since e.g. `a.b.*` also matches `a.b` itself.

For some examples, see the diff of `sym.txt`.

## About the Implementation
Properly handling aliases like `@top tack.b` is a bit difficult since modifiers are commutative.
The implementation I wrote uses a fast-path prefix check first and then, if that fails, a slower and heavily allocating algorithm that goes through all modifiers one-by-one.
That way, an alias `@a b.d` for a symbol `b` with a variant `.c.d` correctly copies that to `a.c`.

For the current symbols, the fast path would have been enough, but I didn't want to sacrifice correctness; This could otherwise come back to haunt us later.\
And since the number of aliases will most likely be staying quite low, such a slow and inefficient fallback should be fine.

## Shallow vs Deep Aliases in `sym`
The rules by which I decided the kind of alias for the pre-existing duplicates are basically the following:
- Does the duplicate include all variants? Then it is a deep alias.
- Otherwise, does one copy have variants and the other doesn't? Then the other is a shallow alias.
- Otherwise, does it seem like there will never be any variants? (e.g. the Hebrew letters) Then also a shallow alias.
- Otherwise, it is a deep alias. (see `nabla`) This is to stay open to the possibility of adding variants to it later.

Of course, as mentioned above, `xor` is a bit of an exception since it was missing one of the variants of `plus.circle`.