### PR TITLE
Add more stars

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -713,7 +713,51 @@ parallelogram
 star
   .op ⋆
   .stroked ☆
+  .stroked.small ⭒
+  .stroked.outlined ⚝
+  .stroked.shadowed ✰
+  .stroked.filled.l ⯪
+  .stroked.filled.r ⯫
   .filled ★
+  .filled.small ⭑
+  .filled.light 🟉
+  .filled.heavy 🟊
+  .filled.l ⯨
+  .filled.r ⯩
+  .filled.outlined ✭
+  .filled.outlined.heavy ✮
+  .pinwheel ✯
+  .three.filled 🟂
+  .three.filled.medium 🟁
+  .three.filled.light 🟀
+  .three.pinwheel 🟃
+  .four.filled 🟆
+  .four.filled.medium 🟅
+  .four.filled.light 🟄
+  .four.pinwheel 🟇
+  .four.pinwheel.rev 🟈
+  .penta ⛤
+  .penta.inv ⛧
+  .penta.laced.l ⛦
+  .penta.laced.r ⛥
+  .six.filled ✶
+  .six.filled.medium 🟋
+  .six.filled.heavy 🟌
+  .six.pinwheel 🟍
+  .six.dot 🔯
+  .six.david ✡
+  .eight.filled ✴
+  .eight.filled.medium 🟎
+  .eight.filled.heavy 🟏
+  .eight.filled.veryheavy 🟐
+  .eight.filled.rect ✷
+  .eight.filled.rect.heavy ✸
+  .eight.pinwheel ✵
+  .eight.pinwheel.heavy 🟑
+  .twelve ✹
+  .twelve.light 🟒
+  .twelve.heavy 🟓
+  .twelve.heavy.pinwheel 🟔
 
 // Arrows, harpoons, and tacks.
 arrow


### PR DESCRIPTION
I'm happy to receive any feedback about the names.

# Unicode Weirdness
## Four-pointed Stars
There's two black four-pointed stars,
- U+2726 "Black Four Pointed Star"
- U+1F7C6 "Four Pointed Black Star"
I chose to go with the second one since the first one is from the "Dingbats" block, not from "Geometric Shapes Extended".
There's also U+2727 "White Four Pointed Star", which I haven't added since it'd be weirdly inconsistent.

## Five-pointed Stars
I'm _assuming_ the original star is intended to be five-pointed (but idk how much of this is just fonts agreeing with each other rather than Unicode actually saying something about it. Where do you get all that secret Unicode information about how characters are supposed to look?)

In particular, note how there's U+1F7C9 "Light Five Pointed Black Star" and U+1F7CA "Heavy Five Pointed Black Star", but no plain "Five Pointed Black Star".
There's also U+066D "Arabic Five Pointed Star", which I don't know what to do with.

Currently, I've added the former two as `star.filled.{light, heavy}`.

## Six-pointed Stars
At least in my font, U+1F52F "Six Pointed Star with Middle Dot" has an emoji style as default. VS15 does work and we should probably only add this one after having resolved #25, but I've added it for now anyway.

## Eight-pointed Stars
U+1F7D0 is called "Very Heavy Eight Pointed Black Star". What do we call this modifier? I've gone with `veryheavy` for now, but I don't think this is a good choice.