### PR TITLE
Add missing dagger variants (Proposal 7)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -118,6 +118,10 @@ colon :
 comma ,
 dagger †
   .double ‡
+  .triple ⹋
+  .l ⸶
+  .r ⸷
+  .inv ⸸
 dash
   .en –
   .em —


### PR DESCRIPTION
This PR implements Proposal 7 (iteration 2) from the [Symbol Proposals document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT). It adds four `dagger` variants.