### PR TITLE
Add power symbols (Proposal 5)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -540,6 +540,12 @@ join ⨝
   .l.r ⟗
 degree °
 smash ⨳
+power
+  .standby ⏻
+  .on ⏽
+  .off ⭘
+  .on.off ⏼
+  .sleep ⏾
 
 // Currency.
 bitcoin ₿


### PR DESCRIPTION
This PR implements Proposal 5 from the [Symbols Proposal Document](https://typst.app/project/pHN_iIPjeuCyI_N2JZB84o), although I tweaked it a little.

In particular, my tweaks are based on https://en.wikipedia.org/wiki/Power_symbol#Unicode,
adding `power.off` with value U+2B58 HEAVY CIRCLE and changing the plain `power` to `power.standby` (since that's what it represents).

IIUC, if the symbol doesn't have a character, it defaults to its first variant, right? That way, `power` without modifiers is also what it is in the proposal.