### PR TITLE
Add tricolon symbols (Proposal 8)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -113,6 +113,8 @@ backslash \
 co ℅
 colon :
   .double ∷
+  .tri ⁝
+  .tri.op ⫶
   .eq ≔
   .double.eq ⩴
 comma ,


### PR DESCRIPTION
This PR adds the symbols from Proposal 8 (iteration 1) from the [Symbols Proposal Document](https://typst.app/project/pHN_iIPjeuCyI_N2JZB84o).

I changed the name from `colon.triple` to `colon.tri` to avoid making it seem related to `colon.double` (which is ∷)
It's also closer to the unicode name (Tricolon).