### PR TITLE
Bring back `diff`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -448,6 +448,7 @@ infinity ∞
   .incomplete ⧜
   .tie ⧝
 oo ∞
+diff ∂
 partial ∂
 gradient ∇
 nabla ∇


### PR DESCRIPTION
The `diff` symbol was removed by https://github.com/typst/typst/pull/5388. What I didn't realize when merging this, is not just that there was no deprecation warning (which was obvious), but that the 0.11.0 changelog said "`diff` will be deprecated in the future". So it wasn't even deprecated at all.

There was also some heated discussion on Discord about `diff` recently, so maybe we should discuss it again before proceeding with the planned deprecation.