### PR TITLE
Add `angstrom` back (with a non-deprecated codepoint)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1037,6 +1037,7 @@ YY 𝕐
 ZZ ℤ
 
 // Miscellaneous letter-likes.
+angstrom Å
 ell ℓ
 planck ℎ
   .reduce ℏ


### PR DESCRIPTION
#14 removed `sym.angstrom` because it used a deprecated codepoint. However, multiple people use this symbol and would have no way of inputting it easily with most keyboards. This PR adds back `sym.angstrom`, except is uses U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE, which is the one that should be used in place of the deprecated U+212B ANGSTROM SIGN.

This follows [a discussion on Discord](https://discord.com/channels/1054443721975922748/1277628305142452306/1336610042685820929).