### PR TITLE
Add struck arrows

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -752,6 +752,7 @@ arrow
   .r.double.long ⟹
   .r.double.long.bar ⟾
   .r.double.not ⇏
+  .r.double.struck ⤃
   .r.filled ➡
   .r.hook ↪
   .r.long ⟶
@@ -762,12 +763,16 @@ arrow
   .r.squiggly ⇝
   .r.stop ⇥
   .r.stroked ⇨
+  .r.struck ⇸
   .r.tail ↣
+  .r.tail.struck ⤔
   .r.tilde ⥲
   .r.triple ⇛
   .r.twohead ↠
   .r.twohead.bar ⤅
+  .r.twohead.struck ⤀
   .r.twohead.tail ⤖
+  .r.twohead.tail.struck ⤗
   .r.wave ↝
   .l ←
   .l.bar ↤
@@ -780,6 +785,7 @@ arrow
   .l.double.long ⟸
   .l.double.long.bar ⟽
   .l.double.not ⇍
+  .l.double.struck ⤂
   .l.filled ⬅
   .l.hook ↩
   .l.long ⟵
@@ -791,12 +797,16 @@ arrow
   .l.squiggly ⇜
   .l.stop ⇤
   .l.stroked ⇦
+  .l.struck ⇷
   .l.tail ↢
+  .l.tail.struck ⬹
   .l.tilde ⭉
   .l.triple ⇚
   .l.twohead ↞
   .l.twohead.bar ⬶
+  .l.twohad.struck ⬴
   .l.twohead.tail ⬻
+  .l.twohead.tail.struck ⬼
   .l.wave ↜
   .t ↑
   .t.bar ↥
@@ -808,6 +818,7 @@ arrow
   .t.quad ⟰
   .t.stop ⤒
   .t.stroked ⇧
+  .t.struck ⤉
   .t.triple ⤊
   .t.twohead ↟
   .b ↓
@@ -820,16 +831,19 @@ arrow
   .b.quad ⟱
   .b.stop ⤓
   .b.stroked ⇩
+  .b.struck ⤈
   .b.triple ⤋
   .b.twohead ↡
   .l.r ↔
   .l.r.double ⇔
   .l.r.double.long ⟺
   .l.r.double.not ⇎
+  .l.r.double.struck ⤄
   .l.r.filled ⬌
   .l.r.long ⟷
   .l.r.not ↮
   .l.r.stroked ⬄
+  .l.r.struck ⇹
   .l.r.wave ↭
   .t.b ↕
   .t.b.double ⇕

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -764,15 +764,19 @@ arrow
   .r.stop ⇥
   .r.stroked ⇨
   .r.struck ⇸
+  .r.dstruck ⇻
   .r.tail ↣
   .r.tail.struck ⤔
+  .r.tail.dstruck ⤕
   .r.tilde ⥲
   .r.triple ⇛
   .r.twohead ↠
   .r.twohead.bar ⤅
   .r.twohead.struck ⤀
+  .r.twohead.dstruck ⤁
   .r.twohead.tail ⤖
   .r.twohead.tail.struck ⤗
+  .r.twohead.tail.dstruck ⤘
   .r.wave ↝
   .l ←
   .l.bar ↤
@@ -798,15 +802,19 @@ arrow
   .l.stop ⇤
   .l.stroked ⇦
   .l.struck ⇷
+  .l.dstruck ⇺
   .l.tail ↢
   .l.tail.struck ⬹
+  .l.tail.dstruck ⬺
   .l.tilde ⭉
   .l.triple ⇚
   .l.twohead ↞
   .l.twohead.bar ⬶
-  .l.twohad.struck ⬴
+  .l.twohead.struck ⬴
+  .l.twohead.dstruck ⬵
   .l.twohead.tail ⬻
   .l.twohead.tail.struck ⬼
+  .l.twohead.tail.dstruck ⬽
   .l.wave ↜
   .t ↑
   .t.bar ↥
@@ -819,6 +827,7 @@ arrow
   .t.stop ⤒
   .t.stroked ⇧
   .t.struck ⤉
+  .t.dstruck ⇞
   .t.triple ⤊
   .t.twohead ↟
   .b ↓
@@ -832,6 +841,7 @@ arrow
   .b.stop ⤓
   .b.stroked ⇩
   .b.struck ⤈
+  .b.dstruck ⇟
   .b.triple ⤋
   .b.twohead ↡
   .l.r ↔
@@ -844,6 +854,7 @@ arrow
   .l.r.not ↮
   .l.r.stroked ⬄
   .l.r.struck ⇹
+  .l.r.dstruck ⇼
   .l.r.wave ↭
   .t.b ↕
   .t.b.double ⇕

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -765,8 +765,9 @@ arrow
   .r.tail ↣
   .r.tilde ⥲
   .r.triple ⇛
-  .r.twohead.bar ⤅
   .r.twohead ↠
+  .r.twohead.bar ⤅
+  .r.twohead.tail ⤖
   .r.wave ↝
   .l ←
   .l.bar ↤
@@ -793,8 +794,9 @@ arrow
   .l.tail ↢
   .l.tilde ⭉
   .l.triple ⇚
-  .l.twohead.bar ⬶
   .l.twohead ↞
+  .l.twohead.bar ⬶
+  .l.twohead.tail ⬻
   .l.wave ↜
   .t ↑
   .t.bar ↥


### PR DESCRIPTION
This PR adds struck arrows, as well as twohead tailed arrows.

For singly struck arrows, I chose the `.struck` modifier, which is consistent with its use in `parallel.struck` in contrast to `parallel.not`. Unicode also defines doubly struck arrows. For those, an additional modifier needs to be created, and i am unsure of the name to use. Maybe `.doublestruck`, or `.dstruck`? I marked the PR as a draft for this reason.