### PR TITLE
Deprecate `diff`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -457,6 +457,7 @@ infinity ∞
   .incomplete ⧜
   .tie ⧝
 oo ∞
+@deprecated: `diff` is deprecated, use `partial` instead
 diff ∂
 partial ∂
 gradient ∇


### PR DESCRIPTION
`diff` was meant to be deprecated since the addition of `partial` in https://github.com/typst/typst/pull/3211. This was indicated in the [Typst 0.11.0 changelog](https://typst.app/docs/changelog/0.11.0/#symbols).