### PR TITLE
Add U+2322 and U+2323

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -570,6 +570,8 @@ power
   .off ⭘
   .on.off ⏼
   .sleep ⏾
+smile ⌣
+frown ⌢
 
 // Currency.
 bitcoin ₿


### PR DESCRIPTION
adds U+2322 `⌢` (frown) and U+2323 `⌣` (smile). they are used in certain cohomology theories for cap and cup products. in latex, they are represented by `\frown` and `\smile`.