### PR TITLE
Add U+00A2 `¢` and U+20B5 `₵`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -573,9 +573,9 @@ power
 
 // Currency.
 bitcoin ₿
-dollar $
 cedi ₵
 cent ¢
+dollar $
 euro €
 franc ₣
 lira ₺

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -574,6 +574,8 @@ power
 // Currency.
 bitcoin ₿
 dollar $
+Cent ₵
+cent ¢
 euro €
 franc ₣
 lira ₺

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -574,7 +574,7 @@ power
 // Currency.
 bitcoin ₿
 dollar $
-Cent ₵
+cedi ₵
 cent ¢
 euro €
 franc ₣


### PR DESCRIPTION
The `¢` "cent" symbol is used when referring to fractional dollars in US currency. The `₵` "cedi" (Ghanaian Cedi) is the legal tender of the Republic of Ghana.