### PR TITLE
Add remaining currency symbols, deprecate franc

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -112,6 +112,7 @@ backslash \
   .not ⧷
 co ℅
 colon :
+  .currency ₡
   .double ∷
   .tri ⁝
   .tri.op ⫶

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -574,23 +574,39 @@ smile ⌣
 frown ⌢
 
 // Currency.
+afghani ؋
+baht ฿
 bitcoin ₿
 cedi ₵
 cent ¢
 dollar $
+dong ₫
+dorome ߾
+dram ֏
 euro €
 @deprecated: `franc` is deprecated, unadopted symbol for currency no longer in use
 franc ₣
+guarani ₲
+hryvnia ₴
+kip ₭
+lari ₾
 lira ₺
+manat ₼
+naira ₦
 peso ₱
 pound £
+riel ៛
 ruble ₽
 rupee
   .indian ₹
   .general ₨
   .tamil ௹
   .wancho 𞋿
+shekel ₪
 taka ৳
+taman ߿
+tenge ₸
+tugrik ₮
 won ₩
 yen ¥
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -579,6 +579,7 @@ cedi ₵
 cent ¢
 dollar $
 euro €
+@deprecated: `franc` is deprecated, unadopted symbol for currency no longer in use
 franc ₣
 lira ₺
 peso ₱

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -585,7 +585,12 @@ lira ₺
 peso ₱
 pound £
 ruble ₽
-rupee ₹
+rupee
+  .indian ₹
+  .general ₨
+  .tamil ௹
+  .wancho 𞋿
+taka ৳
 won ₩
 yen ¥
 


### PR DESCRIPTION
Adds the following currency symbols:

Armenian Dram Sign - dram (Currency of Armenia)
Afghani Sign - afghani (Currency of Aghanistan)
Bengali Rupee Sign - taka (Currency of Bangladesh)
Tamil Rupee Sign - rupee.tamil (Alternative symbol for Indian rupee in the Tamil alphabet)
Thai Currency Symbol Baht - baht (Currency of Thailand)
Khmer Currency Symbol Riel - riel (Currency of Cambodia)
Colon Sign - colon.currency (Currency of Costa Rica)
Naira Sign - naira (Currency of Nigeria)
Rupee sign - rupee.general (Currency of Mauritius, Nepal, Pakistan, Seychelles, Sri Lanka)
New Sheqel Sign - shekel (Currency of Israel)
Dong Sign - dong (Currency of Vietnam)
Kip Sign - kip (Currency of Laos)
Tugrik sign - tugrik (Currency of Mongolia)
Guarani Sign - guarani (Currency of Paraguay)
Hryvnia Sign - hryvnia (Currency of Ukraine)
Tenge Sign - tenge (Currency of Kazakhstan)
Manat Sign - manat (Currency of Azerbaijan)
Lari Sign - lari (Currency of Georgia)
Wancho Ngun Sign - rupee.wancho (Alternative symbol for Indian rupee in the Wancho alphabet)
Nko Dorome Sign - dorome (Currency symbol in the N'ko alphabet)
Nko Taman Sign - taman (Currency symbol in the N'ko alphabet)

Deprecates the following symbol:
French Franc Sign - franc (Not only is the currency no longer in use, the symbol was only a proposal and never used)