### PR TITLE
Add `slash.circle`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -168,6 +168,7 @@ section §
 semi ;
   .rev ⁏
 slash /
+  .circle ⊘
   .double ⫽
   .triple ⫻
   .big ⧸


### PR DESCRIPTION
This adds the name `slash.circle` for the Unicode symbol ⊘, which was inexplicably missing despite seemingly every other circled operator being included. This symbol is sometimes used for Hadamard (element-wise) division, and is available as `\oslash` in LaTeX.