### PR TITLE
Deprecate alternate spellings of hebrew characters

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1051,12 +1051,16 @@ Zeta Ζ
 // from Letterlike Symbols.
 // See https://github.com/typst/typst/pull/3375.
 aleph א
+@deprecated: `alef` is deprecated, use `aleph` instead
 alef א
 beth ב
+@deprecated: `bet` is deprecated, use `beth` instead
 bet ב
+@deprecated: `gimmel` is deprecated, use `gimel` instead
 gimmel ג
 gimel ג
 daleth ד
+@deprecated: `dalet` is deprecated, use `daleth` instead
 dalet ד
 shin ש
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1056,9 +1056,9 @@ alef א
 beth ב
 @deprecated: `bet` is deprecated, use `beth` instead
 bet ב
-@deprecated: `gimmel` is deprecated, use `gimel` instead
-gimmel ג
 gimel ג
+@deprecated: `gimmel` is deprecated, use `gimel` instead
+ gimmel ג
 daleth ד
 @deprecated: `dalet` is deprecated, use `daleth` instead
 dalet ד

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1058,7 +1058,7 @@ beth ב
 bet ב
 gimel ג
 @deprecated: `gimmel` is deprecated, use `gimel` instead
- gimmel ג
+gimmel ג
 daleth ד
 @deprecated: `dalet` is deprecated, use `daleth` instead
 dalet ד


### PR DESCRIPTION
We had two alternate spellings largely because there was no mechanism for deprecation at the time. I'm not opposed to maintaining more than one name for a symbol if they're fundamentally different and there's a good reason for it, but different romanizations is many steps too far in my opinion. A similar example came up recently for the Mongolian currency, which you can find references to as tugrik, tughrik, tugrug, togrog, tögrög, and I'm sure even more.

1. The spellings alef, bet, gimmel and dalet are, as far as I can tell, closer to modern hebrew romanization (actually, "gimmel" seems to be very obscure regardless). However, aleph, beth, gimel and daleth are almost universal in an academic setting, which is where these symbols are intended for.

A search for "alef" on arxiv brings up mostly a bunch of results relating to an author with the last name "Alef" https://arxiv.org/search/?query=alef&searchtype=all, while "aleph" has many relevant results https://arxiv.org/search/?query=aleph&searchtype=all (even excluding the matches to "\aleph").

This is similar to the situation with the greek letters, where "alfa" would have been preferred if we want by romanization.

2. LaTeX uses \aleph, \beth, \gimel and \daleth

3.  HTML uses &aleph, &beth, &gimel and &daleth 