### PR TITLE
Rename circle modifier for symbols that are circled to "o"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,10 @@ mod test {
     #[test]
     fn random_sample() {
         for (key, control) in [
-            ("backslash", [("", "\\"), ("not", "⧷"), ("o", "⦸")].as_slice()),
+            (
+                "backslash",
+                [("", "\\"), ("circle", "⦸"), ("not", "⧷"), ("o", "⦸")].as_slice(),
+            ),
             ("chi", &[("", "χ")]),
             ("forces", &[("", "⊩"), ("not", "⊮")]),
             ("interleave", &[("", "⫴"), ("big", "⫼"), ("struck", "⫵")]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ mod test {
     #[test]
     fn random_sample() {
         for (key, control) in [
-            ("backslash", [("", "\\"), ("o", "⦸"), ("not", "⧷")].as_slice()),
+            ("backslash", [("", "\\"), ("not", "⧷"), ("o", "⦸")].as_slice()),
             ("chi", &[("", "χ")]),
             ("forces", &[("", "⊩"), ("not", "⊮")]),
             ("interleave", &[("", "⫴"), ("big", "⫼"), ("struck", "⫵")]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ mod test {
     #[test]
     fn random_sample() {
         for (key, control) in [
-            ("backslash", [("", "\\"), ("circle", "⦸"), ("not", "⧷")].as_slice()),
+            ("backslash", [("", "\\"), ("o", "⦸"), ("not", "⧷")].as_slice()),
             ("chi", &[("", "χ")]),
             ("forces", &[("", "⊩"), ("not", "⊮")]),
             ("interleave", &[("", "⫴"), ("big", "⫼"), ("struck", "⫵")]),

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -55,6 +55,8 @@ bar
   .v.double ‖
   .v.triple ⦀
   .v.broken ¦
+  .v.o ⦶
+  //Deprecated
   .v.circle ⦶
   .h ―
 fence
@@ -99,15 +101,19 @@ amp &
 // Punctuation.
 ast
   .op ∗
+  .op.o ⊛
   .basic *
   .low ⁎
   .double ⁑
   .triple ⁂
   .small ﹡
+  //Deprecated
   .circle ⊛
   .square ⧆
 at @
 backslash \
+  .o ⦸
+  //Deprecated
   .circle ⦸
   .not ⧷
 co ℅
@@ -132,13 +138,19 @@ dash
   .fig ‒
   .wave 〜
   .colon ∹
+  .o ⊝
+  //Deprecated
   .circle ⊝
   .wave.double 〰
 dot
   .op ⋅
   .basic U+2E
   .c ·
+  .o ⊙
+  .o.big ⨀
+  //Deprecated
   .circle ⊙
+  //Deprecated
   .circle.big ⨀
   .square ⊡
   .double ¨
@@ -229,8 +241,14 @@ prime ′
 
 // Arithmetic.
 plus +
+  .o ⊕
+  .o.arrow ⟴
+  .o.big ⨁
+  //Deprecated
   .circle ⊕
+  //Deprecated
   .circle.arrow ⟴
+  //Deprecated
   .circle.big ⨁
   .dot ∔
   .double ⧺
@@ -240,6 +258,8 @@ plus +
   .triangle ⨹
   .triple ⧻
 minus −
+  .o ⊖
+  //Deprecated
   .circle ⊖
   .dot ∸
   .plus ∓
@@ -247,10 +267,16 @@ minus −
   .tilde ≂
   .triangle ⨺
 div ÷
+  .o ⨸
+  //Deprecated
   .circle ⨸
 times ×
   .big ⨉
+  .o ⊗
+  .o.big ⨂
+  //Deprecated
   .circle ⊗
+  //Deprecated
   .circle.big ⨂
   .div ⋇
   .three.l ⋋
@@ -264,6 +290,8 @@ ratio ∶
 // Relations.
 eq =
   .star ≛
+  .o ⊜
+  //Deprecated
   .circle ⊜
   .colon ≕
   .dots ≑
@@ -285,6 +313,8 @@ eq =
   .triple.not ≢
   .quad ≣
 gt >
+  .o ⧁
+  //Deprecated
   .circle ⧁
   .dot ⋗
   .approx ⪆
@@ -311,6 +341,8 @@ gt >
   .triple ⋙
   .triple.nested ⫸
 lt <
+  .o ⧀
+  //Deprecated
   .circle ⧀
   .dot ⋖
   .approx ⪅
@@ -539,6 +571,8 @@ wreath ≀
 // Geometry.
 parallel ∥
   .struck ⫲
+  .o ⦷
+  //Deprecated
   .circle ⦷
   .eq ⋕
   .equiv ⩨
@@ -548,6 +582,8 @@ parallel ∥
   .slanted.equiv ⧥
   .tilde ⫳
 perp ⟂
+  .o ⦹
+  //Deprecated
   .circle ⦹
 
 // Miscellaneous Technical.

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -699,7 +699,6 @@ bullet •
 circle
   .stroked ○
   .stroked.tiny ∘
-  .stroked.tiny.o ⊚ 
   .stroked.small ⚬
   .stroked.big ◯
   .filled ●
@@ -707,7 +706,7 @@ circle
   .filled.small ∙
   .filled.big ⬤
   .dotted ◌
-  //Deprecated
+  //Deprecated, use compose.o
   .nested ⊚
 ellipse
   .stroked.h ⬭

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -56,7 +56,7 @@ bar
   .v.triple ⦀
   .v.broken ¦
   .v.o ⦶
-  //Deprecated
+  @deprecated: `bar.v.circle` is deprecated, use `bar.v.o` instead
   .v.circle ⦶
   .h ―
 fence
@@ -108,13 +108,13 @@ ast
   .low ⁎
   .double ⁑
   .triple ⁂
-  //Deprecated
+  @deprecated: `ast.circle` is deprecated, use `convolve.o` or `ast.op.o` instead
   .circle ⊛
   .square ⧆
 at @
 backslash \
   .o ⦸
-  //Deprecated
+  @deprecated: `backslash.circle` is deprecated, use `backslash.o` instead
   .circle ⦸
   .not ⧷
 co ℅
@@ -142,7 +142,7 @@ dash
   .wave 〜
   .colon ∹
   .o ⊝
-  //Deprecated
+  @deprecated: `dash.circle` is deprecated, use `dash.o` instead
   .circle ⊝
   .wave.double 〰
 dot
@@ -151,9 +151,9 @@ dot
   .c ·
   .o ⊙
   .o.big ⨀
-  //Deprecated
+  @deprecated: `dot.circle` is deprecated, use `dot.o` instead
   .circle ⊙
-  //Deprecated
+  @deprecated: `dot.circle.big` is deprecated, use `dot.o.big` instead
   .circle.big ⨀
   .square ⊡
   .double ¨
@@ -251,11 +251,11 @@ plus +
   .o ⊕
   .o.arrow ⟴
   .o.big ⨁
-  //Deprecated
+  @deprecated: `plus.circle` is deprecated, use `plus.o` instead
   .circle ⊕
-  //Deprecated
+  @deprecated: `plus.circle.arrow` is deprecated, use `plus.o.arrow` instead
   .circle.arrow ⟴
-  //Deprecated
+  @deprecated: `plus.circle.big` is deprecated, use `plus.o.big` instead
   .circle.big ⨁
   .dot ∔
   .double ⧺
@@ -265,7 +265,7 @@ plus +
   .triple ⧻
 minus −
   .o ⊖
-  //Deprecated
+  @deprecated: `minus.circle` is deprecated, use `minus.o` instead
   .circle ⊖
   .dot ∸
   .plus ∓
@@ -274,15 +274,15 @@ minus −
   .triangle ⨺
 div ÷
   .o ⨸
-  //Deprecated
+  @deprecated: `div.circle` is deprecated, use `div.o` instead
   .circle ⨸
 times ×
   .big ⨉
   .o ⊗
   .o.big ⨂
-  //Deprecated
+  @deprecated: `times.circle` is deprecated, use `times.o` instead
   .circle ⊗
-  //Deprecated
+  @deprecated: `times.circle.big` is deprecated, use `times.o.big` instead
   .circle.big ⨂
   .div ⋇
   .three.l ⋋
@@ -297,7 +297,7 @@ ratio ∶
 eq =
   .star ≛
   .o ⊜
-  //Deprecated
+  @deprecated: `eq.circle` is deprecated, use `eq.o` instead
   .circle ⊜
   .colon ≕
   .dots ≑
@@ -319,7 +319,7 @@ eq =
   .quad ≣
 gt >
   .o ⧁
-  //Deprecated
+  @deprecated: `gt.circle` is deprecated, use `gt.o` instead
   .circle ⧁
   .dot ⋗
   .approx ⪆
@@ -346,7 +346,7 @@ gt >
   .triple.nested ⫸
 lt <
   .o ⧀
-  //Deprecated
+  @deprecated: `lt.circle` is deprecated, use `lt.o` instead
   .circle ⧀
   .dot ⋖
   .approx ⪅
@@ -578,7 +578,7 @@ angzarr ⍼
 parallel ∥
   .struck ⫲
   .o ⦷
-  //Deprecated
+  @deprecated: `parallel.circle` is deprecated, use `parallel.o` instead
   .circle ⦷
   .eq ⋕
   .equiv ⩨
@@ -589,7 +589,7 @@ parallel ∥
   .tilde ⫳
 perp ⟂
   .o ⦹
-  //Deprecated
+  @deprecated: `perp.circle` is deprecated, use `perp.o` instead
   .circle ⦹
 
 // Astronomical.
@@ -724,6 +724,8 @@ bullet •
 circle
   .stroked ○
   .stroked.tiny ∘
+  @deprecated: `circled.stroked.tiny.o` is deprecated, use `compose.o` instead
+  .stroked.tiny.o 
   .stroked.small ⚬
   .stroked.big ◯
   .filled ●
@@ -731,7 +733,7 @@ circle
   .filled.small ∙
   .filled.big ⬤
   .dotted ◌
-  //Deprecated, use compose.o
+  @deprecated: `circle.nested` is deprecated, use `compose.o` instead
   .nested ⊚
 ellipse
   .stroked.h ⬭

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -699,6 +699,7 @@ bullet •
 circle
   .stroked ○
   .stroked.tiny ∘
+  .stroked.tiny.o ⊚ 
   .stroked.small ⚬
   .stroked.big ◯
   .filled ●
@@ -706,6 +707,7 @@ circle
   .filled.small ∙
   .filled.big ⬤
   .dotted ◌
+  //Deprecated
   .nested ⊚
 ellipse
   .stroked.h ⬭

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -724,8 +724,6 @@ bullet •
 circle
   .stroked ○
   .stroked.tiny ∘
-  @deprecated: `circled.stroked.tiny.o` is deprecated, use `compose.o` instead
-  .stroked.tiny.o 
   .stroked.small ⚬
   .stroked.big ◯
   .filled ●

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -184,7 +184,7 @@ semi ;
   .inv ⸵
   .rev ⁏
 slash /
-  .circle ⊘
+  .o ⊘
   .double ⫽
   .triple ⫻
   .big ⧸

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -551,7 +551,9 @@ qed ∎
 mapsto ↦
   .long ⟼
 compose ∘
+  .o ⊚
 convolve ∗
+  .o ⊛
 multimap ⊸
   .double ⧟
 


### PR DESCRIPTION
This is in conflict with https://github.com/typst/codex/issues/34 . However, circled symbols are _extremely_ common, both in terms of the number of characters (we're still missing a bunch of symbols) and in usage. Therefore, I believe that it deserves its own short and cute modifier, which also has the benefit of resolving the ambiguous conflicting uses of "circle". There is also precedence, in the form of "oo" to mean infinity.

Notes:
- ast.circle was really a circled variant of ast.op, so I used ast.op.o.
- circle.nested was really a circled variant of circle.stroked.tiny, so I used circle.stroked.tiny.o
- The aliases compose.o and convolve.o were missing. I added them

I initially wanted to add additional symbols in this PR, but in the process of looking into this I discovered a number of issues that should ideally be resolved first. I therefore prioritized just getting the ball rolling.