### PR TITLE
Remove chinese compatibility characters

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -103,7 +103,6 @@ ast
   .low ⁎
   .double ⁑
   .triple ⁂
-  .small ﹡
   .circle ⊛
   .square ⧆
 at @
@@ -235,7 +234,6 @@ plus +
   .dot ∔
   .double ⧺
   .minus ±
-  .small ﹢
   .square ⊞
   .triangle ⨹
   .triple ⧻
@@ -279,7 +277,6 @@ eq =
   .not ≠
   .prec ⋞
   .quest ≟
-  .small ﹦
   .succ ⋟
   .triple ≡
   .triple.not ≢
@@ -301,7 +298,6 @@ gt >
   .nequiv ≩
   .not ≯
   .ntilde ⋧
-  .small ﹥
   .tilde ≳
   .tilde.not ≵
   .tri ⊳
@@ -327,7 +323,6 @@ lt <
   .nequiv ≨
   .not ≮
   .ntilde ⋦
-  .small ﹤
   .tilde ≲
   .tilde.not ≴
   .tri ⊲


### PR DESCRIPTION
Remove the `small` variants of `ast`, `plus`, `eq`, `gt` and `lt`.

These are compatibility symbols for Chinese in the [Small Form Variants](https://en.wikipedia.org/wiki/Small_Form_Variants) block, and should not have been added in the first place.