### PR TITLE
Add permyriad symbol

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -162,6 +162,7 @@ hyph ‐
 numero №
 percent %
 permille ‰
+permyriad ‱
 pilcrow ¶
   .rev ⁋
 section §


### PR DESCRIPTION
As noted in the the proposals document (™️), the symbol is much less used than percent and permille. However, I see no reason to not include it. The name should be fairly uncontroversial.