### PR TITLE
Add astronomical symbols

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -550,6 +550,20 @@ parallel ∥
 perp ⟂
   .circle ⦹
 
+// Astronomical.
+earth 🜨
+  .alt ♁
+jupiter ♃
+mars ♂
+mercury ☿
+neptune ♆
+  .alt ⯉
+saturn ♄
+sun ☉
+uranus ⛢
+  .alt ♅
+venus ♀
+
 // Miscellaneous Technical.
 diameter ⌀
 interleave ⫴


### PR DESCRIPTION
Adds various astronomical symbols. These days, I believe only the symbols for the sun, earth and jupiter are commonly used in actual science, but do see use in astrology.

There's also
- ♇ for Pluto, but I skipped that one since it's no longer a planet.
- A bunch of moon symbols, some which can act as emojis