### PR TITLE
Add angzarr

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -537,6 +537,7 @@ divides ∣
 wreath ≀
 
 // Geometry.
+angzarr ⍼
 parallel ∥
   .struck ⫲
   .circle ⦷


### PR DESCRIPTION
We were missing the most important unicode symbol.

Context: https://en.wikipedia.org/wiki/Angzarr