### PR TITLE
Add cyrillic sha

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1043,6 +1043,12 @@ Upsilon Υ
 Xi Ξ
 Zeta Ζ
 
+// Lowercase Cyrillic.
+sha ш
+
+// Uppercase Cyrillic.
+Sha Ш
+
 // Hebrew.
 // In math, the following symbols are replaced with corresponding characters
 // from Letterlike Symbols.


### PR DESCRIPTION
To my knowledge, this is the only cyrillic letter that has seen widespread use as a symbol.

Math fonts seem to mostly have either no cyrillic letters (such as NCMM) or all of them (such as Stix Two Math).

It's unfortunate that the default font does not have it, but it is what it is.