### PR TITLE
Rename angle brackets and quotes to chevron

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -63,7 +63,7 @@ fence
   .r ⧙
   .r.double ⧛
   .dotted ⦙
-angle ∠
+chevron
   .l ⟨
   .l.curly ⧼
   .l.dot ⦑
@@ -71,6 +71,23 @@ angle ∠
   .r ⟩
   .r.curly ⧽
   .r.dot ⦒
+  .r.double ⟫
+angle ∠
+  //Deprecated, use chevron.l
+  .l ⟨
+  //Deprecated, use chevron.l.curly
+  .l.curly ⧼
+  //Deprecated, use chevron.l.dot
+  .l.dot ⦑
+  //Deprecated, use chevron.l.double
+  .l.double ⟪
+  //Deprecated, use chevron.r
+  .r ⟩
+  //Deprecated, use chevron.r.curly
+  .r.curly ⧽
+  //Deprecated, use chevron.r.dot
+  .r.dot ⦒
+  //Deprecated, use chevron.r.double
   .r.double ⟫
   .acute ⦟
   .arc ∡

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -546,6 +546,7 @@ angle ∠
   .acute ⦟
   .arc ∡
   .arc.rev ⦛
+  .azimuth ⍼
   .oblique ⦦
   .rev ⦣
   .right ∟

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -72,38 +72,6 @@ chevron
   .r.curly ⧽
   .r.dot ⦒
   .r.double ⟫
-angle ∠
-  //Deprecated, use chevron.l
-  .l ⟨
-  //Deprecated, use chevron.l.curly
-  .l.curly ⧼
-  //Deprecated, use chevron.l.dot
-  .l.dot ⦑
-  //Deprecated, use chevron.l.double
-  .l.double ⟪
-  //Deprecated, use chevron.r
-  .r ⟩
-  //Deprecated, use chevron.r.curly
-  .r.curly ⧽
-  //Deprecated, use chevron.r.dot
-  .r.dot ⦒
-  //Deprecated, use chevron.r.double
-  .r.double ⟫
-  .acute ⦟
-  .arc ∡
-  .arc.rev ⦛
-  .oblique ⦦
-  .rev ⦣
-  .right ∟
-  .right.rev ⯾
-  .right.arc ⊾
-  .right.dot ⦝
-  .right.sq ⦜
-  .s ⦞
-  .spatial ⟀
-  .spheric ∢
-  .spheric.rev ⦠
-  .spheric.top ⦡
 ceil
   .l ⌈
   .r ⌉
@@ -550,6 +518,38 @@ divides ∣
 wreath ≀
 
 // Geometry.
+angle ∠
+  //Deprecated, use chevron.l
+  .l ⟨
+  //Deprecated, use chevron.l.curly
+  .l.curly ⧼
+  //Deprecated, use chevron.l.dot
+  .l.dot ⦑
+  //Deprecated, use chevron.l.double
+  .l.double ⟪
+  //Deprecated, use chevron.r
+  .r ⟩
+  //Deprecated, use chevron.r.curly
+  .r.curly ⧽
+  //Deprecated, use chevron.r.dot
+  .r.dot ⦒
+  //Deprecated, use chevron.r.double
+  .r.double ⟫
+  .acute ⦟
+  .arc ∡
+  .arc.rev ⦛
+  .oblique ⦦
+  .rev ⦣
+  .right ∟
+  .right.rev ⯾
+  .right.arc ⊾
+  .right.dot ⦝
+  .right.sq ⦜
+  .s ⦞
+  .spatial ⟀
+  .spheric ∢
+  .spheric.rev ⦠
+  .spheric.top ⦡
 angzarr ⍼
 parallel ∥
   .struck ⫲

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -203,13 +203,13 @@ quote
   .chevron.l.single ‹
   .chevron.r.double »
   .chevron.r.single ›
-  //Deprecated, use quote.chevron.l.double
+  @deprecated: `quote.angle.l.double` is deprecated, use `quote.chevron.l.double` instead
   .angle.l.double «
-  //Deprecated, use quote.chevron.l.single
+  @deprecated: `quote.angle.l.single` is deprecated, use `quote.chevron.l.single` instead
   .angle.l.single ‹
-  //Deprecated, use quote.chevron.r.double
+  @deprecated: `quote.angle.r.double` is deprecated, use `quote.chevron.r.double` instead
   .angle.r.double »
-  //Deprecated, use quote.chevron.r.single
+  @deprecated: `quote.angle.r.single` is deprecated, use `quote.chevron.r.single` instead
   .angle.r.single ›
   .high.double ‟
   .high.single ‛
@@ -532,21 +532,21 @@ wreath ≀
 
 // Geometry.
 angle ∠
-  //Deprecated, use chevron.l
+  @deprecated: `angle.l` is deprecated, use `chevron.l` instead
   .l ⟨
-  //Deprecated, use chevron.l.curly
+  @deprecated: `angle.l.curly` is deprecated, use `chevron.l.curly` instead
   .l.curly ⧼
-  //Deprecated, use chevron.l.dot
+  @deprecated: `angle.l.dot` is deprecated, use `chevron.l.dot` instead
   .l.dot ⦑
-  //Deprecated, use chevron.l.double
+  @deprecated: `angle.l.double` is deprecated, use `chevron.l.double` instead
   .l.double ⟪
-  //Deprecated, use chevron.r
+  @deprecated: `angle.r` is deprecated, use `chevron.r` instead
   .r ⟩
-  //Deprecated, use chevron.r.curly
+  @deprecated: `angle.r.curly` is deprecated, use `chevron.r.curly` instead
   .r.curly ⧽
-  //Deprecated, use chevron.r.dot
+  @deprecated: `angle.r.dot` is deprecated, use `chevron.r.dot` instead
   .r.dot ⦒
-  //Deprecated, use chevron.r.double
+  @deprecated: `angle.r.double` is deprecated, use `chevron.r.double` instead
   .r.double ⟫
   .acute ⦟
   .arc ∡

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -194,9 +194,17 @@ quote
   .l.single ‘
   .r.double ”
   .r.single ’
+  .chevron.l.double «
+  .chevron.l.single ‹
+  .chevron.r.double »
+  .chevron.r.single ›
+  //Deprecated, use quote.chevron.l.double
   .angle.l.double «
+  //Deprecated, use quote.chevron.l.single
   .angle.l.single ‹
+  //Deprecated, use quote.chevron.r.double
   .angle.r.double »
+  //Deprecated, use quote.chevron.r.single
   .angle.r.single ›
   .high.double ‟
   .high.single ‛


### PR DESCRIPTION
Currently, we had two entirely different families of symbols under `angle`. Namely all the angle brackets, and the geometry kind. I've renamed the brackets to chevron, which is an alternate name for them that someone suggested. At the same time, I moved the remaining angles to the "Geometry" section.

For consistency, I also renamed `quote.angle` to `quote.chevron`.