### PR TITLE
Add most missing delimiters (and more)

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -27,24 +27,24 @@ paren
   .l.flat ⟮
   .l.bar ⦇
   .l.stroked ⦅
-  //Deprecated, use paren.l.stroked
+  @deprecated: `paren.l.double` is deprecated, use `paren.l.stroked` instead
   .l.double ⦅
   .r )
   .r.flat ⟯
   .r.bar ⦈
   .r.stroked ⦆
-  //Deprecated, use paren.r.stroked
+  @deprecated: `paren.r.double` is deprecated, use `paren.r.stroked` instead
   .r.double ⦆
   .t ⏜
   .b ⏝
 brace
   .l U+7B
   .l.stroked ⦃
-  //Deprecated, use brace.l.stroked
+  @deprecated: `brace.l.double` is deprecated, use `brace.l.stroked` instead
   .l.double ⦃
   .r U+7D
   .r.stroked ⦄
-  //Deprecated, use brace.r.stroked
+  @deprecated: `brace.r.double` is deprecated, use `brace.r.stroked` instead
   .r.double ⦄
   .t ⏞
   .b ⏟
@@ -53,13 +53,13 @@ bracket
   .l.tick.t ⦍
   .l.tick.b ⦏
   .l.stroked ⟦
-  //Deprecated, use bracket.l.stroked
+  @deprecated: `bracket.l.double` is deprecated, use `bracket.l.stroked` instead
   .l.double ⟦
   .r ]
   .r.tick.t ⦐
   .r.tick.b ⦎
   .r.stroked ⟧
-  //Deprecated, use bracket.r.stroked
+  @deprecated: `bracket.r.double` is deprecated, use `bracket.r.stroked` instead
   .r.double ⟧
   .t ⎴
   .b ⎵
@@ -67,12 +67,12 @@ shell
   .l ❲
   .l.stroked ⟬
   .l.filled ⦗
-  //Deprecated, use shell.l.stroked
+  @deprecated: `shell.l.double` is deprecated, use `shell.l.stroked` instead
   .l.double ⟬
   .r ❳
   .r.stroked ⟭
   .r.filled ⦘
-  //Deprecated, use shell.r.stroked
+  @deprecated: `shell.r.double` is deprecated, use `shell.r.stroked` instead
   .r.double ⟭
   .t ⏠
   .b ⏡

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -24,32 +24,64 @@ space U+20
 // Delimiters.
 paren
   .l (
+  .l.flat ⟮
+  .l.bar ⦇
+  .l.stroked ⦅
+  //Deprecated, use paren.l.stroked
   .l.double ⦅
   .r )
+  .r.flat ⟯
+  .r.bar ⦈
+  .r.stroked ⦆
+  //Deprecated, use paren.r.stroked
   .r.double ⦆
   .t ⏜
   .b ⏝
 brace
   .l U+7B
+  .l.stroked ⦃
+  //Deprecated, use brace.l.stroked
   .l.double ⦃
   .r U+7D
+  .r.stroked ⦄
+  //Deprecated, use brace.r.stroked
   .r.double ⦄
   .t ⏞
   .b ⏟
 bracket
   .l [
+  .l.tick.t ⦍
+  .l.tick.b ⦏
+  .l.stroked ⟦
+  //Deprecated, use bracket.l.stroked
   .l.double ⟦
   .r ]
+  .r.tick.t ⦐
+  .r.tick.b ⦎
+  .r.stroked ⟧
+  //Deprecated, use bracket.r.stroked
   .r.double ⟧
   .t ⎴
   .b ⎵
 shell
   .l ❲
+  .l.stroked ⟬
+  .l.filled ⦗
+  //Deprecated, use shell.l.stroked
   .l.double ⟬
   .r ❳
+  .r.stroked ⟭
+  .r.filled ⦘
+  //Deprecated, use shell.r.stroked
   .r.double ⟭
   .t ⏠
   .b ⏡
+bag
+  .l ⟅
+  .r ⟆
+moustache
+  .l ⎰
+  .r ⎱
 bar
   .v |
   .v.double ‖
@@ -63,14 +95,21 @@ fence
   .r ⧙
   .r.double ⧛
   .dotted ⦙
+corner
+  .l.t ⌜
+  .l.b ⌞
+  .r.t ⌝
+  .r.b ⌟
 angle ∠
   .l ⟨
   .l.curly ⧼
   .l.dot ⦑
+  .l.bar ⦉
   .l.double ⟪
   .r ⟩
   .r.curly ⧽
   .r.dot ⦒
+  .r.bar ⦊
   .r.double ⟫
   .acute ⦟
   .arc ∡
@@ -93,10 +132,10 @@ ceil
 floor
   .l ⌊
   .r ⌋
-amp &
-  .inv ⅋
 
 // Punctuation.
+amp &
+  .inv ⅋
 ast
   .op ∗
   .basic *


### PR DESCRIPTION
Adds most of the missing delimiters. These are still missing, mostly because I struggle with naming:
⦌  right square bracket with underbar (U+298C) 
⦔ right arc greater-than bracket (U+2994)
⦖ double right arc less-than bracket (U+2996) 

The first one would be easier to name once we have a name for the "undermacron".

The proposal document also lists double parentheses, but those do not seem to be math delimiters. I'm not sure what they are exactly, but they're not present in any font I tried.

- I renamed some of the `double` variants to `stroked` for consistency. This is especially important for the tortoise shells, since there is a filled variant.
- I hope the distinction between `bar` (meant to indicate the delimiter) and `stroked` is clear enough.
- I moved `amp` to punctuation, as it was in the wrong place.
- There is some weirdness regarding `fence`. `fence.dotted` is not a delimiter, and seems entirely unrelated. I didn't do anything with it, however.