### PR TITLE
Rename angle.spheric.top to angle.spheric.t

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -86,6 +86,8 @@ angle ∠
   .spatial ⟀
   .spheric ∢
   .spheric.rev ⦠
+  .spheric.t ⦡
+  //Deprecated
   .spheric.top ⦡
 ceil
   .l ⌈

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -87,7 +87,7 @@ angle ∠
   .spheric ∢
   .spheric.rev ⦠
   .spheric.t ⦡
-  //Deprecated
+  // Deprecated.
   .spheric.top ⦡
 ceil
   .l ⌈


### PR DESCRIPTION
The current name was inconsistent with our naming scheme.

There's also a broader discussion to be had whether all the `.rev` variants we have make sense. If there is a "canonical" direction, such as for `in`, then yes, but I have no idea what to expect for `angle.spheric`. It would better to use names like `angle.spheric.r`, `angle.spheric.l` and `angle.spheric.t` to indicate which way it opens.

I didn't make that change, but the same comment applies to `angle.rev`, `angle.right.rev`, and `angle.arc.rev`