### PR TITLE
Chess

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -619,29 +619,47 @@ suit
 chess {
     king
       .white ♔
+      .white.inv 🨞
       .black ♚
+      .black.inv 🨤
       .neutral 🨀
+      .neutral.inv 🨪
     queen
       .white ♕
+      .white.inv 🨟
       .black ♛
+      .black.inv 🨥
       .neutral 🨁
+      .neutral.inv 🨫
     rook
       .white ♖
+      .white.inv 🨠
       .black ♜
+      .black.inv 🨦
       .neutral 🨂
+      .neutral.inv 🨬
     bishop
       .white ♗
+      .white.inv 🨡
       .black ♝
+      .black.inv 🨧
       .neutral 🨃
+      .neutral.inv 🨭
     knight
       .white ♘
+      .white.inv 🨢
       .black ♞
+      .black.inv 🨨
       .neutral 🨄
+      .neutral 🨮
     pawn
       .white ♙
+      .white.inv 🨣
       .black ♟
+      .black.inv 🨩
       .neutral 🨅
-    shogi
+      .neutral.inv 🨯
+    koma
       .white ☖
       .white.inv ⛉
       .black ☗

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -619,43 +619,62 @@ suit
 chess {
     king
       .white ♔
+      .white.r 🨉
       .white.inv 🨞
       .black ♚
+      .black.r 🨏
       .black.inv 🨤
       .neutral 🨀
+      .nautral.r 🨕
       .neutral.inv 🨪
     queen
       .white ♕
+      .white.r 🨊
       .white.inv 🨟
       .black ♛
+      .black.r 🨐
       .black.inv 🨥
       .neutral 🨁
+      .neutral.r 🨖
       .neutral.inv 🨫
     rook
       .white ♖
+      .white.r 🨋
       .white.inv 🨠
       .black ♜
+      .black.r 🨑
       .black.inv 🨦
       .neutral 🨂
+      .neutral.r 🨗
       .neutral.inv 🨬
     bishop
       .white ♗
+      .white.r 🨌
       .white.inv 🨡
       .black ♝
+      .black.r 🨒
       .black.inv 🨧
       .neutral 🨃
+      .neutral.r 🨘
       .neutral.inv 🨭
     knight
       .white ♘
+      .white.tr 🨆
+      .white.r 🨍
       .white.inv 🨢
       .black ♞
+      .black.tr 🨇
+      .black.r 🨓
       .black.inv 🨨
       .neutral 🨄
-      .neutral 🨮
+      .neutral.tr 🨈
+      .neutral.r 🨙
+      .neutral.inv 🨮
     pawn
       .white ♙
       .white.inv 🨣
       .black ♟
+      .black.r 🨔
       .black.inv 🨩
       .neutral 🨅
       .neutral.inv 🨯

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -693,7 +693,7 @@ chess {
       .neutral.inv 🨮
       .neutral.bl 🨲
       .neutral.l 🩃
-      .neutral.tl
+      .neutral.tl 🩇
     pawn
       .white ♙
       .white.r 🨎

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -675,11 +675,13 @@ chess {
       .neutral.bl 🨲
     pawn
       .white ♙
+      .white.r 🨎
       .white.inv 🨣
       .black ♟
       .black.r 🨔
       .black.inv 🨩
       .neutral 🨅
+      .neutral.r 🨚
       .neutral.inv 🨯
     koma
       .white ☖

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -621,68 +621,92 @@ chess {
       .white ♔
       .white.r 🨉
       .white.inv 🨞
+      .white.l 🨳
       .black ♚
       .black.r 🨏
       .black.inv 🨤
+      .black.l 🨹
       .neutral 🨀
-      .nautral.r 🨕
+      .neutral.r 🨕
       .neutral.inv 🨪
+      .neutral.l 🨿
     queen
       .white ♕
       .white.r 🨊
       .white.inv 🨟
+      .white.l 🨴
       .black ♛
       .black.r 🨐
       .black.inv 🨥
+      .black.l 🨺
       .neutral 🨁
       .neutral.r 🨖
       .neutral.inv 🨫
+      .neutral.l 🩀
     rook
       .white ♖
       .white.r 🨋
       .white.inv 🨠
+      .white.l 🨵
       .black ♜
       .black.r 🨑
       .black.inv 🨦
+      .black.l 🨻
       .neutral 🨂
       .neutral.r 🨗
       .neutral.inv 🨬
+      .neutral.l 🩁
     bishop
       .white ♗
       .white.r 🨌
       .white.inv 🨡
+      .white.l 🨶
       .black ♝
       .black.r 🨒
       .black.inv 🨧
+      .black.l 🨼
       .neutral 🨃
       .neutral.r 🨘
       .neutral.inv 🨭
+      .neutral.l 🩂
     knight
       .white ♘
       .white.tr 🨆
       .white.r 🨍
+      .white.br 🨛
       .white.inv 🨢
       .white.bl 🨰
+      .white.l 🨷
+      .white.tl 🩅
       .black ♞
       .black.tr 🨇
       .black.r 🨓
+      .black.br 🨜
       .black.inv 🨨
       .black.bl 🨱
+      .black.l 🨽
+      .black.tl 🩆
       .neutral 🨄
       .neutral.tr 🨈
       .neutral.r 🨙
+      .neutral.bl 🨝
       .neutral.inv 🨮
       .neutral.bl 🨲
+      .neutral.l 🩃
+      .neutral.tl
     pawn
       .white ♙
       .white.r 🨎
       .white.inv 🨣
+      .white.l 🨸
       .black ♟
       .black.r 🨔
       .black.inv 🨩
+      .black.l 🨾
       .neutral 🨅
       .neutral.r 🨚
       .neutral.inv 🨯
+      .neutral.l 🩄
     koma
       .white ☖
       .white.inv ⛉

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -616,6 +616,39 @@ suit
   .spade.filled ♠
   .spade.stroked ♤
 
+chess {
+    king
+      .white ♔
+      .black ♚
+      .neutral 🨀
+    queen
+      .white ♕
+      .black ♛
+      .neutral 🨁
+    rook
+      .white ♖
+      .black ♜
+      .neutral 🨂
+    bishop
+      .white ♗
+      .black ♝
+      .neutral 🨃
+    knight
+      .white ♘
+      .black ♞
+      .neutral 🨄
+    pawn
+      .white ♙
+      .black ♟
+      .neutral 🨅
+    shogi
+      .white ☖
+      .white.inv ⛉
+      .black ☗
+      .black.inv ⛊
+}
+
+
 // Music.
 note
   .up 🎜

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -662,14 +662,17 @@ chess {
       .white.tr 🨆
       .white.r 🨍
       .white.inv 🨢
+      .white.bl 🨰
       .black ♞
       .black.tr 🨇
       .black.r 🨓
       .black.inv 🨨
+      .black.bl 🨱
       .neutral 🨄
       .neutral.tr 🨈
       .neutral.r 🨙
       .neutral.inv 🨮
+      .neutral.bl 🨲
     pawn
       .white ♙
       .white.inv 🨣

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -707,11 +707,48 @@ chess {
       .neutral.r 🨚
       .neutral.inv 🨯
       .neutral.l 🩄
+    equihopper
+      .white 🩈
+      .white.rot 🩋
+      .black 🩉
+      .black.rot 🩌
+      .neutral 🩊
+      .neutral.rot 🩍
+    amazon
+      .white 🩎
+      .black 🩑
+    empress
+      .white 🩏
+      .black 🩒
+    princess
+      .white 🩐
+      .black 🩓
     koma
       .white ☖
       .white.inv ⛉
       .black ☗
       .black.inv ⛊
+    general
+      .red 🩠
+      .black 🩧
+    mandarin
+      .red 🩡
+      .black 🩨
+    elephant
+      .red 🩢
+      .black 🩩
+    horse
+      .red 🩣
+      .black 🩪
+    chariot
+      .red 🩤
+      .black 🩫
+    cannon
+      .red 🩥
+      .black 🩬
+    soldier
+      .red 🩦
+      .black 🩭
 }
 
 


### PR DESCRIPTION
There's an ungodly number of these symbols, so I'd be surprised if I got everything right.

I mostly followed @MDLC01, though:
- I used only black/white and black/red instead of having stroked/filled as aliases, since these carry an actual meaning here.
- I opted to call the inverted pieces `.inv` instead of `.b`. I believe they are more common than the other rotated variants.
- I used the names amazon, empress and princess for the fairy pieces
- I also added the shogi pieces (koma)

There's also 4 symbols for draughts, but they don't seem like they fit under chess.