### PR TITLE
Add mahjong tiles

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1132,6 +1132,60 @@ errorbar
   .circle.stroked ⧲
   .circle.filled ⧳
 
+mahjong {
+  wind
+    .east 🀀
+    .south 🀁
+    .west 🀂
+    .north 🀃
+  dragon
+    .red 🀄︎
+    .green 🀅
+    .white 🀆
+  character
+    .one 🀇
+    .two 🀈
+    .three 🀉
+    .four 🀊
+    .five 🀋
+    .six 🀌
+    .seven 🀍
+    .eight 🀎
+    .nine 🀏
+  bamboo
+    .one 🀐
+    .two 🀑
+    .three 🀒
+    .four 🀓
+    .five 🀔
+    .six 🀕
+    .seven 🀖
+    .eight 🀗
+    .nine 🀘
+  circle
+    .one 🀙
+    .two 🀚
+    .three 🀛
+    .four 🀜
+    .five 🀝
+    .six 🀞
+    .seven 🀟
+    .eight 🀠
+    .nine 🀡
+  flower
+    .plum 🀢
+    .orchid 🀣
+    .bamboo 🀤
+    .chrysanthemum 🀥
+  season
+    .spring 🀦
+    .summer 🀧
+    .autumn 🀨
+    .winter 🀩
+  joker 🀪
+  back 🀫
+}
+
 gender {
   female ♀
     .double ⚢


### PR DESCRIPTION
Each suit has multiple different names. I went with the ones used in the official unicode names.

The red dragon tile needs a variation selector, so this cannot be merged yet.