### PR TITLE
Add recycling symbols

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -638,7 +638,7 @@ recycle
   .plastic.five ♷
   .plastic.six ♸
   .plastic.seven ♹
-  .paper.fully ♼
+  .paper ♼
   .paper.partial ♽
   .paper.permanent ♾︎
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -627,6 +627,21 @@ suit
   .spade.filled ♠
   .spade.stroked ♤
 
+recycle
+  .stroked ♲
+  .filled ♻︎
+  .generic ♺
+  .plastic.one ♳
+  .plastic.two ♴
+  .plastic.three ♵
+  .plastic.four ♶
+  .plastic.five ♷
+  .plastic.six ♸
+  .plastic.seven ♹
+  .paper.fully ♼
+  .paper.partial ♽
+  .paper.permanent ♾︎
+
 // Music.
 note
   .up 🎜


### PR DESCRIPTION
The permanent paper sign is not technically a recycling symbol, but it's closely related and I'd not sure where else it'd go.

Two of the symbols need text variation selectors.

I went with "recycle" instead of "recycling" since it's shorter, but I can be convinced either way.