### PR TITLE
Change some of the more incorrectly (?) named emojis

### DIFF
--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -391,7 +391,6 @@ diamond
   .orange.small 🔸
   .dot 💠
 die 🎲
-dino
 sauropod 🦕
 trex 🦖
 disc
@@ -1058,7 +1057,6 @@ placard 🪧
 planet 🪐
 plant 🪴
 plaster 🩹
-plate
 plate 🍽
 playback
   .down ⏬

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -1059,7 +1059,7 @@ planet 🪐
 plant 🪴
 plaster 🩹
 plate
-  .silverware 🍽
+plate 🍽
 playback
   .down ⏬
   .eject ⏏

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -195,7 +195,7 @@ calendar 📅
   .spiral 🗓
   .tearoff 📆
 camel 🐫
-  .dromedary 🐪
+dromedary 🐪
 camera 📷
   .flash 📸
   .movie 🎥

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -392,8 +392,8 @@ diamond
   .dot 💠
 die 🎲
 dino
-  .sauropod 🦕
-  .trex 🦖
+sauropod 🦕
+trex 🦖
 disc
   .cd 💿
   .dvd 📀

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -1143,7 +1143,7 @@ santa
   .man 🎅
   .woman 🤶
 satellite 🛰
-  .dish 📡
+antenna 📡
 saw 🪚
 saxophone 🎷
 scales ⚖

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -3,7 +3,7 @@ abc 🔤
 abcd 🔡
 ABCD 🔠
 accordion 🪗
-aesculapius ⚕
+asclepius ⚕
 airplane ✈
   .landing 🛬
   .small 🛩
@@ -49,7 +49,7 @@ ast *
   .box ✳
 atm 🏧
 atom ⚛
-aubergine 🍆
+eggplant 🍆
 avocado 🥑
 axe 🪓
 baby 👶
@@ -72,7 +72,7 @@ banjo 🪕
 bank 🏦
 barberpole 💈
 baseball ⚾
-basecap 🧢
+cap 🧢
 basket 🧺
 basketball ⛹
   .ball 🏀
@@ -95,7 +95,7 @@ beer 🍺
   .clink 🍻
 beet 🫜
 beetle 🪲
-  .lady 🐞
+ladybug 🐞
 bell 🔔
   .ding 🛎
   .not 🔕
@@ -106,7 +106,7 @@ bike 🚲
   .not 🚳
 bikini 👙
 billiards 🎱
-bin 🗑
+wastebasket 🗑
 biohazard ☣
 bird 🐦
 bison 🦬
@@ -195,7 +195,7 @@ calendar 📅
   .spiral 🗓
   .tearoff 📆
 camel 🐫
-  .dromedar 🐪
+  .dromedary 🐪
 camera 📷
   .flash 📸
   .movie 🎥
@@ -217,10 +217,10 @@ car 🚗
 card
   .credit 💳
   .id 🪪
-cardindex 📇
+rolodex 📇
 carrot 🥕
 cart 🛒
-cassette 📼
+vhs 📼
 castle
   .eu 🏰
   .jp 🏯
@@ -284,9 +284,9 @@ city 🏙
 clamp 🗜
 clapperboard 🎬
 climbing 🧗
-clip 📎
+paperclip 📎
+  .linked 🖇
 clipboard 📋
-clips 🖇
 clock
   .one 🕐
   .one.thirty 🕜
@@ -363,7 +363,7 @@ crossmark ❌
   .box ❎
 crown 👑
 crutch 🩼
-crystal 🔮
+crystalball 🔮
 cucumber 🥒
 cup
   .straw 🥤
@@ -372,7 +372,7 @@ curling 🥌
 curry 🍛
 custard 🍮
 customs 🛃
-cutlery 🍴
+silverware 🍴
 cyclone 🌀
 dancing
   .man 🕺
@@ -392,8 +392,8 @@ diamond
   .dot 💠
 die 🎲
 dino
-  .pod 🦕
-  .rex 🦖
+  .sauropod 🦕
+  .trex 🦖
 disc
   .cd 💿
   .dvd 📀
@@ -562,8 +562,7 @@ falafel 🧆
 family 👪
 fax 📠
 feather 🪶
-feeding
-  .breast 🤱
+breastfeeding 🤱
 fencing 🤺
 ferriswheel 🎡
 filebox 🗃
@@ -633,7 +632,7 @@ fries 🍟
 frisbee 🥏
 frog
   .face 🐸
-fuelpump ⛽
+gaspump ⛽
 garlic 🧄
 gear ⚙
 gem 💎
@@ -730,7 +729,7 @@ heart ❤
   .yellow 💛
 hedgehog 🦔
 helicopter 🚁
-helix 🧬
+dna 🧬
 helmet
   .cross ⛑
   .military 🪖
@@ -940,7 +939,7 @@ mouse 🐁
 mousetrap 🪤
 mouth 👄
   .bite 🫦
-moyai 🗿
+moai 🗿
 museum 🏛
 mushroom 🍄
 musicalscore 🎼
@@ -995,7 +994,7 @@ parachute 🪂
 park 🏞
 parking 🅿
 parrot 🦜
-partalteration 〽
+partalternation 〽
 party 🎉
 peach 🍑
 peacock 🦚
@@ -1060,7 +1059,7 @@ planet 🪐
 plant 🪴
 plaster 🩹
 plate
-  .cutlery 🍽
+  .silverware 🍽
 playback
   .down ⏬
   .eject ⏏
@@ -1110,14 +1109,13 @@ rabbit 🐇
 raccoon 🦝
 radio 📻
 radioactive ☢
-railway 🛤
+railroad 🛤
 rainbow 🌈
 ram 🐏
 rat 🐀
 razor 🪒
 receipt 🧾
 recycling ♻
-reg ®
 restroom 🚻
 rhino 🦏
 ribbon 🎀
@@ -1127,7 +1125,7 @@ rice 🍚
   .ear 🌾
   .onigiri 🍙
 ring 💍
-ringbuoy 🛟
+lifebuoy 🛟
 robot 🤖
 rock 🪨
 rocket 🚀
@@ -1146,8 +1144,8 @@ sandwich 🥪
 santa
   .man 🎅
   .woman 🤶
-satdish 📡
 satellite 🛰
+  .dish 📡
 saw 🪚
 saxophone 🎷
 scales ⚖
@@ -1184,7 +1182,7 @@ shoe 👞
   .ski 🎿
   .sneaker 👟
   .tall 👢
-  .thong 🩴
+  .flipflop 🩴
 shopping 🛍
 shorts 🩳
 shoshinsha 🔰
@@ -1317,7 +1315,8 @@ ticket
   .travel 🎫
 tiger 🐅
   .face 🐯
-tm ™
+trademark ™
+  .registered ®
 toilet 🚽
 toiletpaper 🧻
 tomato 🍅
@@ -1350,8 +1349,9 @@ train 🚆
 transgender ⚧
 tray
   .inbox 📥
-  .mail 📨
   .outbox 📤
+envelope ✉️
+  .incoming 📨
 tree
   .deciduous 🌳
   .evergreen 🌲
@@ -1382,7 +1382,6 @@ umbrella
   .rain ☔
   .sun ⛱
 unicorn 🦄
-unknown 🦳
 up 🆙
 urn ⚱
 vampire 🧛


### PR DESCRIPTION
Current emoji naming is very inconsistent, and in some cases wrong. I initially started taking notes for every single emoji, but that turned out to simply be too much. This is a more constrained PR renaming some of the more clear cut cases as a start

We probably need some deprecation warnings if we want to proceed here, but I wanted to get feedback before adding them.

aesculapius -> asclepius: The former is the latin name. A more radical naming would be "medical"

aubergine -> eggplant: This is the name in US english

basecap -> cap: The former seems to be an example of https://en.wikipedia.org/wiki/Pseudo-anglicism . We could use "baseballcap" or "cap.baseball", but I don't think there are other cap emojis.

beetle.lady -> ladybug: This is the name in US english

bin -> wastebasket: Bin is rarely used in US english

camel.dromedar -> camel.dromedary: This was either a typo, or the German name.

cardindex -> rolodex: More common name, and it's literally what the emoji is depicting

cassette -> vhs: Cassette is more commonly used for audio cassettes, while the emoji depicts a video cassette (vhs).

clip -> paperclip: I'm not aware that the short form "clip" is used for this.
clips -> paperclip.linked: See above. An alternative is "paperclips", but the emoji does specifically depict linked paperclips.

crystal -> crystalball: I honestly think this might have just been an oversight?

cutlery -> silverware: Again, this is the most common terminology in US english

dino.pod -> dino.sauropod: The original name was strange. Alternatively "dino.saur" or just "dinosaur" or "sauropod"
dino.rex -> dino.trex: Alternatively just "trex"

feeding.breast -> breastfeeding

fuelpump -> gaspump: Common name in US english. Fuel pump can also mean other things.

helix -> dna: The emoji specifically depicts the DNA double helix.

moyai -> moai: typo?

partalteration -> partalternation: typo (as an aside, this seems very obscure)

railway -> railroad: US english

ringbuoy -> lifebuoy: US english

satdish -> satellite.dish

shoe.thong -> shoe.flipflop: US english

tm -> trademark: Alignment with symbols.txt
reg -> trademark.registered: Alignment with symbols.txt

envelope: This emoji was missing
tray.mail -> envelope.incoming: This seems to have been misplaced under tray.

unknown: Removed, since this was the "white hair" emoji component, and not an actual emoji.