### PR TITLE
Add digamma

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -997,6 +997,7 @@ beta β
   .alt ϐ
 chi χ
 delta δ
+digamma ϝ
 epsilon ε
   .alt ϵ
 eta η
@@ -1031,6 +1032,7 @@ Alpha Α
 Beta Β
 Chi Χ
 Delta Δ
+Digamma Ϝ
 Epsilon Ε
 Eta Η
 Gamma Γ


### PR DESCRIPTION
This is an archaic greek letter, but it does see use (though rarely), and appears in reasonably complete math fonts. It's also the only one that gets a name in unicode-math (the latex package).

Other archaic symbols exist, but I don't think there is a point in adding them unless requested. 