### PR TITLE
Add Theta.alt

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1050,6 +1050,7 @@ Rho Ρ
 Sigma Σ
 Tau Τ
 Theta Θ
+  .alt ϴ
 Upsilon Υ
 Xi Ξ
 Zeta Ζ


### PR DESCRIPTION
I happened to notice in https://us.mirrors.cicku.me/ctan/macros/unicodetex/latex/unicode-math/unimath-symbols.pdf that a single capital Greek letter has an alternate version, and that we were missing it.