### PR TITLE
Add Unicode 17 emoji

### DIFF
--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -17,6 +17,7 @@ anchor ⚓
 anger 💢
 ant 🐜
 apple
+  .core 🫝
   .green 🍏
   .red 🍎
 arm
@@ -102,6 +103,7 @@ bell 🔔
 bento 🍱
 bicyclist 🚴
   .mountain 🚵
+bigfoot 🫈
 bike 🚲
   .not 🚳
 bikini 👙
@@ -317,6 +319,7 @@ clock
   .timer ⏲
 cloud ☁
   .dust 💨
+  .fight 🫯
   .rain 🌧
   .snow 🌨
   .storm ⛈
@@ -460,6 +463,7 @@ face
   .devil.frown 👿
   .diagonal 🫤
   .disguise 🥸
+  .distorted 🫪
   .distress 😫
   .dizzy 😵
   .dotted 🫥
@@ -902,6 +906,7 @@ mirror 🪞
 mixer 🎛
 money
   .bag 💰
+  .chest 🪎
   .dollar 💵
   .euro 💶
   .pound 💷
@@ -1130,6 +1135,7 @@ ring 💍
 ringbuoy 🛟
 robot 🤖
 rock 🪨
+  .slide 🛘
 rocket 🚀
 rollercoaster 🎢
 rosette 🏵
@@ -1367,6 +1373,7 @@ triangle
   .b.red 🔻
 trident 🔱
 troll 🧌
+trombone 🪊
 trophy 🏆
 truck 🚚
   .trailer 🚛
@@ -1401,6 +1408,7 @@ wave 🌊
 wc 🚾
 weightlifting 🏋
 whale 🐋
+  .orca 🫍
   .spout 🐳
 wheel 🛞
 wheelchair 🦽


### PR DESCRIPTION
Unicode 17 is still a few months away but I noticed a draft list of the new emoji is already [online](https://www.unicode.org/emoji/charts-17.0/emoji-released.html).

<details><summary>Emoji added</summary>

1FAEA distorted face
1FAEF fight cloud
1FAC8 hairy creature
1FACD orca
1FADD apple core
1F6D8 landslide
1FA8A trombone
1FA8E treasure chest
</details> 

**Some notes:**

`cloud.fight`: Not sure this fits under `cloud`.

`whale.orca`: Orca or killer whale?

`rock.slide`: Might be better under `mountain`.

`money.chest`: `treasure` instead?

Unicode 17 also introduces skin tone variants for ballet dancer, people wrestling, and people with bunny ears, which I haven’t included.