### PR TITLE
Allow deprecating variants

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -87,7 +87,7 @@ angle ∠
   .spheric ∢
   .spheric.rev ⦠
   .spheric.t ⦡
-  // Deprecated.
+  @deprecated: `angle.spheric.top` is deprecated, use `angle.spheric.t` instead
   .spheric.top ⦡
 ceil
   .l ⌈
@@ -481,7 +481,7 @@ integral ∫
   .double ∬
   .quad ⨌
   .inter ⨙
-  // Deprecated.
+  @deprecated: `integral.sect` is deprecated, use `integral.inter` instead
   .sect ⨙
   .slash ⨏
   .square ⨖


### PR DESCRIPTION
This allows deprecating variants, which I did for the two variants that are already deprecated. I will start working on a corresponding typst/typst PR soon. I may wait until https://github.com/typst/typst/pull/6159 is merged first.

With the current system, there is a weird edge case where modifierless variants can be deprecated independently of the symbol itself, although there is no syntactical way to deprecate a modifierless variant in out DSL. I don't think this is too much of an issue. It could even prove useful if we want to change the default variant of symbol (first, mark the modifierless variant as deprecated, then, in a future version, change its value and remove the deprecation), although this will require adding new syntax at this point.