### PR TITLE
Add `eq.dot.up` and `eq.dot.down`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -272,6 +272,8 @@ eq =
   .star ≛
   .circle ⊜
   .colon ≕
+  .dot.up ≐
+  .dot.down ⩦
   .dots ≑
   .dots.down ≒
   .dots.up ≓


### PR DESCRIPTION
hi, this PR adds the symbols U+2250 Approaches the Limit ([thanks](https://discord.com/channels/1054443721975922748/1088371919725793360/1381955865086791740)) and U+2A66 Equals Sign with Dot Below as `eq.dot.up` and `eq.dot.down`. not sure if the names are right (not a lot of precedent). also added the `up` variant first because it's probably what a user is expecting when they type `eq.dot`, and it's analogous to LaTeX doteq