### PR TITLE
Implement shorter modifier name for slanted equal and equiv

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -289,6 +289,11 @@ eq =
   .triple ≡
   .triple.not ≢
   .quad ≣
+seq
+  .lt ⪕
+  .lt.dot ⪗
+  .gt ⪖
+  .gt.dot ⪘
 gt >
   .circle ⧁
   .dot ⋗
@@ -296,6 +301,7 @@ gt >
   .double ≫
   .eq ≥
   .seq ⩾
+  .dot.seq ⪀
   @deprecated: `gt.eq.slant` is deprecated, use `gt.seq` instead
   .eq.slant ⩾
   .eq.lt ⋛
@@ -323,6 +329,7 @@ lt <
   .double ≪
   .eq ≤
   .seq ⩽
+  .dot.seq ⩿
   @deprecated: `lt.eq.slant` is deprecated, use `lt.seq` instead
   .eq.slant ⩽
   .eq.gt ⋚

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -295,6 +295,8 @@ gt >
   .approx ⪆
   .double ≫
   .eq ≥
+  .seq ⩾
+  @deprecated: `gt.eq.slant` is deprecated, use `gt.seq` instead
   .eq.slant ⩾
   .eq.lt ⋛
   .eq.not ≱
@@ -320,6 +322,8 @@ lt <
   .approx ⪅
   .double ≪
   .eq ≤
+  .seq ⩽
+  @deprecated: `lt.eq.slant` is deprecated, use `lt.seq` instead
   .eq.slant ⩽
   .eq.gt ⋚
   .eq.not ≰
@@ -344,7 +348,11 @@ approx ≈
   .not ≉
 prec ≺
   .approx ⪷
+  .seq ≼
+  @deprecated: `prec.curly.eq` is deprecated, use `prec.seq` instead
   .curly.eq ≼
+  .seq.not ⋠
+  @deprecated: `prec.curly.eq.not` is deprecated, use `prec.seq.not` instead
   .curly.eq.not ⋠
   .double ⪻
   .eq ⪯
@@ -357,7 +365,11 @@ prec ≺
   .tilde ≾
 succ ≻
   .approx ⪸
+  .seq ≽
+  @deprecated: `prec.curly.eq` is deprecated, use `prec.seq` instead
   .curly.eq ≽
+  .seq.not ⋡
+  @deprecated: `prec.curly.eq.not` is deprecated, use `prec.seq.not` instead
   .curly.eq.not ⋡
   .double ⪼
   .eq ⪰

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -307,6 +307,7 @@ gt >
   .eq.lt ⋛
   .eq.not ≱
   .equiv ≧
+  .sequiv ⫺
   .lt ≷
   .lt.not ≹
   .neq ⪈
@@ -335,6 +336,7 @@ lt <
   .eq.gt ⋚
   .eq.not ≰
   .equiv ≦
+  .sequiv ⫹
   .gt ≶
   .gt.not ≸
   .neq ⪇
@@ -389,6 +391,9 @@ succ ≻
   .tilde ≿
 equiv ≡
   .not ≢
+sequiv
+  .lt ⪛
+  .gt ⪜
 smt ⪪
   .eq ⪬
 lat ⪫


### PR DESCRIPTION
This implements the changes described in #42. Also
- Add additional related variants that should be uncontroversial based on existing choices. There are some more in the document ™, but they require more discussion.
- Naturally introduce the corresponding `sequiv`.
- This should unblock https://github.com/typst/codex/pull/36, since curly is now freed up

While there a few concerns that have been voiced, I've also not seen any viable alternative for resolving ambiguity. Even `seq` is not enough to resolve ambiguity for some of the more cursed symbols (⪓).