### PR TITLE
Allow multi-character symbols/variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,15 @@ pub enum Def {
 #[derive(Debug, Copy, Clone)]
 pub enum Symbol {
     /// A symbol without modifiers.
-    Single(char),
+    Single(&'static str),
     /// A symbol with named modifiers. The symbol defaults to its first variant.
-    Multi(&'static [(ModifierSet<&'static str>, char, Option<&'static str>)]),
+    Multi(&'static [(ModifierSet<&'static str>, &'static str, Option<&'static str>)]),
 }
 
 impl Symbol {
     /// Get the symbol's character for a given set of modifiers, alongside an optional deprecation
     /// message.
-    pub fn get(&self, modifs: ModifierSet<&str>) -> Option<(char, Option<&str>)> {
+    pub fn get(&self, modifs: ModifierSet<&str>) -> Option<(&'static str, Option<&str>)> {
         match self {
             Self::Single(c) => modifs.is_empty().then_some((*c, None)),
             Self::Multi(list) => {
@@ -81,13 +81,13 @@ impl Symbol {
     /// Each variant is represented by a tuple `(modifiers, character, deprecation)`.
     pub fn variants(
         &self,
-    ) -> impl Iterator<Item = (ModifierSet<&str>, char, Option<&str>)> {
+    ) -> impl Iterator<Item = (ModifierSet<&str>, &'static str, Option<&str>)> {
         enum Variants {
-            Single(std::iter::Once<char>),
+            Single(std::iter::Once<&'static str>),
             Multi(
                 std::slice::Iter<
                     'static,
-                    (ModifierSet<&'static str>, char, Option<&'static str>),
+                    (ModifierSet<&'static str>, &'static str, Option<&'static str>),
                 >,
             ),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ include!(concat!(env!("OUT_DIR"), "/out.rs"));
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn all_modules_sorted() {
@@ -147,5 +148,37 @@ mod test {
             space.get(ModifierSet::from_raw_dotted("nobreak")).unwrap().0,
             "\u{A0}"
         );
+    }
+
+    #[test]
+    fn random_sample() {
+        for (key, control) in [
+            ("backslash", [("", "\\"), ("circle", "⦸"), ("not", "⧷")].as_slice()),
+            ("chi", &[("", "χ")]),
+            ("forces", &[("", "⊩"), ("not", "⊮")]),
+            ("interleave", &[("", "⫴"), ("big", "⫼"), ("struck", "⫵")]),
+            ("uranus", &[("", "⛢"), ("alt", "♅")]),
+        ] {
+            let Def::Symbol(s) = SYM.get(key).unwrap().def else {
+                panic!("{key:?} is not a symbol")
+            };
+            let variants = s
+                .variants()
+                .map(|(m, v, _)| (m.into_iter().collect::<BTreeSet<_>>(), v))
+                .collect::<BTreeSet<_>>();
+            let control = control
+                .iter()
+                .map(|&(m, v)| {
+                    (
+                        ModifierSet::from_raw_dotted(m)
+                            .into_iter()
+                            .collect::<BTreeSet<_>>(),
+                        v,
+                    )
+                })
+                .collect::<BTreeSet<_>>();
+
+            assert_eq!(variants, control);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,4 +136,16 @@ mod test {
 
         assert_sorted_recursively(ROOT);
     }
+
+    #[test]
+    fn unicode_escapes() {
+        let Def::Symbol(wj) = SYM.get("wj").unwrap().def else { panic!() };
+        assert_eq!(wj.get(ModifierSet::default()).unwrap().0, "\u{2060}");
+        let Def::Symbol(space) = SYM.get("space").unwrap().def else { panic!() };
+        assert_eq!(space.get(ModifierSet::default()).unwrap().0, " ");
+        assert_eq!(
+            space.get(ModifierSet::from_raw_dotted("nobreak")).unwrap().0,
+            "\u{A0}"
+        );
+    }
 }

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1,25 +1,25 @@
 // Control.
-wj U+2060
-zwj U+200D
-zwnj U+200C
-zws U+200B
-lrm U+200E
-rlm U+200F
+wj \u{2060}
+zwj \u{200D}
+zwnj \u{200C}
+zws \u{200B}
+lrm \u{200E}
+rlm \u{200F}
 
 // Spaces.
-space U+20
-  .nobreak U+A0
-  .nobreak.narrow U+202F
-  .en U+2002
-  .quad U+2003
-  .third U+2004
-  .quarter U+2005
-  .sixth U+2006
-  .med U+205F
-  .fig U+2007
-  .punct U+2008
-  .thin U+2009
-  .hair U+200A
+space \u{20}
+  .nobreak \u{A0}
+  .nobreak.narrow \u{202F}
+  .en \u{2002}
+  .quad \u{2003}
+  .third \u{2004}
+  .quarter \u{2005}
+  .sixth \u{2006}
+  .med \u{205F}
+  .fig \u{2007}
+  .punct \u{2008}
+  .thin \u{2009}
+  .hair \u{200A}
 
 // Delimiters.
 paren
@@ -30,9 +30,9 @@ paren
   .t ⏜
   .b ⏝
 brace
-  .l U+7B
+  .l \u{7B}
   .l.double ⦃
-  .r U+7D
+  .r \u{7D}
   .r.double ⦄
   .t ⏞
   .b ⏟
@@ -141,14 +141,14 @@ dash
   .wave.double 〰
 dot
   .op ⋅
-  .basic U+2E
+  .basic \u{2E}
   .c ·
   .circle ⊙
   .circle.big ⨀
   .square ⊡
   .double ¨
-  .triple U+20DB
-  .quad U+20DC
+  .triple \u{20DB}
+  .quad \u{20DC}
 excl !
   .double ‼
   .inv ¡
@@ -161,10 +161,10 @@ interrobang ‽
   .inv ⸘
 hash #
 hyph ‐
-  .minus U+2D
-  .nobreak U+2011
+  .minus \u{2D}
+  .nobreak \u{2011}
   .point ‧
-  .soft U+AD
+  .soft \u{AD}
 numero №
 percent %
 permille ‰


### PR DESCRIPTION
This just changes all instances of `char` to `&str`/`String`.

Some notes:
- Allocating every variant in `build.rs` was the easiest way to do it. I'd have at least two other ideas about how to reduce allocations, but both require a bit more code complexity, so idk if it'd be worth it.
- The way the multi-character syntax interacts with `U+XXXX` escapes is by just treating each `U+` as the start of one and always taking the maximal hex value following that. I think this is fine, since we don't have any symbols or variants whose values contain hex digits anyway.

Future work would be updating `sym.txt` and `emoji.txt` to resolve #25. For that, I'd like to extend the syntax with suffixes `!text` and `!emoji` that get converted to `U+FE0E` and `U+FE0F`, so that it's less cryptic. Not sure if either of those changes (the suffix parsing and the actual updating of the module files) should be done in this PR or in a follow-up. I'd like some opinions on that.