### PR TITLE
Additional circled mathematical symbols

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -281,7 +281,7 @@ minus −
   .triangle ⨺
 div ÷
   .o ⨸
-  .o.slant ⦼
+  .slanted.o ⦼
   @deprecated: `div.circle` is deprecated, use `div.o` instead
   .circle ⨸
 times ×

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -252,6 +252,8 @@ prime ′
 // Arithmetic.
 plus +
   .o ⊕
+  .o.l ⨭
+  .o.r ⨮
   .o.arrow ⟴
   .o.big ⨁
   @deprecated: `plus.circle` is deprecated, use `plus.o` instead
@@ -279,11 +281,16 @@ minus −
   .triangle ⨺
 div ÷
   .o ⨸
+  .o.slant ⦼
   @deprecated: `div.circle` is deprecated, use `div.o` instead
   .circle ⨸
 times ×
   .big ⨉
   .o ⊗
+  .o.double ⨷
+  .o.l ⨴
+  .o.r ⨵
+  .o.hat ⨶
   .o.big ⨂
   @deprecated: `times.circle` is deprecated, use `times.o` instead
   .circle ⊗

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -287,7 +287,6 @@ div ÷
 times ×
   .big ⨉
   .o ⊗
-  .o.double ⨷
   .o.l ⨴
   .o.r ⨵
   .o.hat ⨶


### PR DESCRIPTION
To my knowledge, these are the remaining circled mathematical operators in unicode.

There are a multitude more symbols in other categories, plus a generic composing circle (https://www.compart.com/en/unicode/U+20DD), but it seems natural to leave those for the future.

- Curiously, while there is a circled slanted division sign, there is no non-circled one.
- I debated whether I should add `.half` to `plus.o.l` etc, but ended up not doing that. The choice here is the same as in @MDLC01 's document.
- I think `times.o.o` would be a better name than `times.o.double`, but this is impossible right now.