### PR TITLE
Add bag and moustache delimiters

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -50,6 +50,12 @@ shell
   .r.double ⟭
   .t ⏠
   .b ⏡
+bag
+  .l ⟅
+  .r ⟆
+moustache
+  .l ⎰
+  .r ⎱
 bar
   .v |
   .v.double ‖


### PR DESCRIPTION
Note: The moustache name is used in both HTML and LaTeX. It's more distinctive than the unicode one.