### PR TITLE
Move ampersand from delimiters to punctuation

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -97,10 +97,10 @@ ceil
 floor
   .l ⌊
   .r ⌋
-amp &
-  .inv ⅋
 
 // Punctuation.
+amp &
+  .inv ⅋
 ast
   .op ∗
   .op.o ⊛


### PR DESCRIPTION
Should be fairly self-explanatory. The symbol was put in the wrong part of the file at some point.