### PR TITLE
Add various flavors of double delimiters

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -24,29 +24,49 @@ space \u{20}
 // Delimiters.
 paren
   .l (
+  .l.closed ⦇
+  .l.stroked ⦅
+  @deprecated: `paren.l.double` is deprecated, use `paren.l.stroked` instead
   .l.double ⦅
   .r )
+  .r.closed ⦈
+  .r.stroked ⦆
+  @deprecated: `paren.r.double` is deprecated, use `paren.r.stroked` instead
   .r.double ⦆
   .t ⏜
   .b ⏝
 brace
   .l \u{7B}
+  .l.stroked ⦃
+  @deprecated: `brace.l.double` is deprecated, use `brace.l.stroked` instead
   .l.double ⦃
   .r \u{7D}
+  .r.stroked ⦄
+  @deprecated: `brace.r.double` is deprecated, use `brace.r.stroked` instead
   .r.double ⦄
   .t ⏞
   .b ⏟
 bracket
   .l [
+  .l.stroked ⟦
+  @deprecated: `bracket.l.double` is deprecated, use `bracket.l.stroked` instead
   .l.double ⟦
   .r ]
+  .r.stroked ⟧
+  @deprecated: `bracket.r.double` is deprecated, use `bracket.r.stroked` instead
   .r.double ⟧
   .t ⎴
   .b ⎵
 shell
   .l ❲
+  .l.stroked ⟬
+  .l.filled ⦗
+  @deprecated: `shell.l.double` is deprecated, use `shell.l.stroked` instead
   .l.double ⟬
   .r ❳
+  .r.stroked ⟭
+  .r.filled ⦘
+  @deprecated: `shell.r.double` is deprecated, use `shell.r.stroked` instead
   .r.double ⟭
   .t ⏠
   .b ⏡
@@ -69,10 +89,12 @@ angle ∠
   .l ⟨
   .l.curly ⧼
   .l.dot ⦑
+  .l.closed ⦉
   .l.double ⟪
   .r ⟩
   .r.curly ⧽
   .r.dot ⦒
+  .r.closed ⦊
   .r.double ⟫
   .acute ⦟
   .arc ∡


### PR DESCRIPTION
Context: There are in essence four different types of double delimiters

1. "True" double delimiters, where the symbol is repeated twice

Based on naming conventions , these should get the `.double` modifier. I don't think this point is controversial.

2. A single delimiter closed with a vertical line (Comes from "Z-notation")

I called these `.bar` in the previous iteration, but used `.closed` here (following @MDLC01 's suggestion ). I'm not entirely happy with either name.

3. Black / filled delimiters.

There is only one pair of these, namely the tortoise shells ⦗ and ⦘. These don't show up correctly here, but here is what they look like in Noto Sans Math and Stix Two Math:

![image](https://github.com/user-attachments/assets/601ba34e-15c2-4ccc-b89d-44d4263d6876)

(They are completely broken in New Computer Modern Math)

The natural name is `.filled`

4. White / double-struck / stroked delimiters.

Currently we have a number of these introduced as `.double`, but this is not consistent with our typical naming. It also causes issues:
- There are actual doubled parentheses ⸨ and ⸩ in unicode (not compatibility characters!). While they are not mathematical delimiters, we may still want to add them to codex at some point, and `paren.l.double` / `paren.r.double` would be the natural names for them then.
- The tortoise shells above are the filled in variants of these:

![image](https://github.com/user-attachments/assets/01e275ef-69bf-4f60-915c-78fe4d668c47)

which should therefore get the name `.stroked`. To quote @MDLC01 "If we have .stroked we should have it for everything that is not filled".