### PR TITLE
Fix some gendered emoji

### DIFF
--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -377,7 +377,9 @@ cyclone 🌀
 dancing
   .man 🕺
   .woman 💃
-  .women.bunny 👯
+  .bunny 👯
+  .bunny.men 👯‍♂
+  .bunny.women 👯‍♀
 darts 🎯
 dash
   .wave.double 〰

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -703,7 +703,7 @@ hand
 handbag 👜
 handball 🤾
 handfan 🪭
-handholding
+handholding 🧑‍🤝‍🧑
   .man.man 👬
   .woman.man 👫
   .woman.woman 👭


### PR DESCRIPTION
### People with Bunny ears
These have been changed to be gender-neutral (in Unicode 9.0, according to [this](https://www.unicode.org/L2/L2024/24252-toned-multi-person-zwj-seq.pdf)).

I also added the gender-specific ZWJ sequences while I was at it, since multi-character symbols are now possible.

Source: https://www.unicode.org/reports/tr51/#multiperson_gender

### People holding hands
This is a ZWJ sequence, unlike the other three legacy variants.
I feel like this one only makes sense to also have, now that we can.

---

Not sure if we should actually merge this before [typst#6489](https://github.com/typst/typst/pull/6489), but it's probably fine since I'm pretty sure that that will land before the next release.