### PR TITLE
Implement optional modifiers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,7 +154,7 @@ fn tokenize(line: &str) -> StrResult<Line> {
         Line::ModuleEnd
     } else if let Some(rest) = head.strip_prefix('.') {
         for part in rest.split('.') {
-            validate_ident(part)?;
+            validate_ident(part.strip_suffix('?').unwrap_or(part))?;
         }
         let value = decode_value(tail.ok_or("missing char")?)?;
         Line::Variant(ModifierSet::from_raw_dotted(rest), value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl Symbol {
     /// Possible modifiers for this symbol.
     pub fn modifiers(&self) -> impl Iterator<Item = &str> + '_ {
         self.variants()
-            .flat_map(|(m, _, _)| m.into_iter())
+            .flat_map(|(m, _, _)| m.into_iter().map(|m| m.strip_suffix('?').unwrap_or(m)))
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,4 +190,89 @@ mod test {
             assert_eq!(variants, control);
         }
     }
+
+    #[test]
+    fn no_overlap() {
+        recur("", ROOT);
+
+        /// Iterate over all symbols in a module, recursing into submodules.
+        fn recur(prefix: &str, m: Module) {
+            for (name, b) in m.iter() {
+                match b.def {
+                    Def::Module(m) => {
+                        let new_prefix = if prefix.is_empty() {
+                            name.to_string()
+                        } else {
+                            prefix.to_string() + "." + name
+                        };
+                        recur(&new_prefix, m);
+                    }
+                    Def::Symbol(s) => check_symbol(prefix, name, s),
+                }
+            }
+        }
+
+        /// Check the no overlap rule for a single symbol
+        fn check_symbol(prefix: &str, name: &str, sym: Symbol) {
+            // maximum number of modifiers per variant (we don't need to check more than this).
+            let max_modifs =
+                sym.variants().map(|(m, ..)| m.iter().count()).max().unwrap();
+            let modifs = sym.modifiers().collect::<Vec<_>>();
+            let max_index = modifs.len().saturating_sub(1);
+
+            for k in 0..=max_modifs {
+                let mut indices = (0..k).collect::<Vec<_>>();
+                loop {
+                    let mset = indices.iter().map(|i| modifs[*i]).fold(
+                        ModifierSet::<String>::default(),
+                        |mut res, m| {
+                            res.insert_raw(m);
+                            res
+                        },
+                    );
+
+                    if sym.variants().filter(|(m, ..)| mset.is_candidate(*m)).count() > 1
+                    {
+                        panic!(
+                            "Overlap in symbol {prefix}.{name} for modifiers {}",
+                            mset.as_str()
+                        );
+                    }
+
+                    if next_subseq(&mut indices, max_index).is_none() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// Produce the next term in a sequence like
+        /// ```text
+        /// [0,1,2], [0,1,3], [0,1,4], [0,2,3], [0,2,4], [0,3,4], [1,2,3], [1,2,4], [1,3,4], [2,3,4]
+        /// ```
+        fn next_subseq(indices: &mut [usize], max_index: usize) -> Option<()> {
+            // invariant: indices.len() <= max_index + 1
+            match indices {
+                [] => None,
+                [single] => {
+                    if *single < max_index {
+                        *single += 1;
+                        Some(())
+                    } else {
+                        None
+                    }
+                }
+                [left @ .., last] => {
+                    assert_ne!(max_index, 0);
+                    if *last < max_index {
+                        *last += 1;
+                    } else {
+                        next_subseq(left, max_index - 1)?;
+                        *last = left.last().copied().map_or(*last, |x| x + 1);
+                    }
+                    Some(())
+                }
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl Symbol {
     /// Possible modifiers for this symbol.
     pub fn modifiers(&self) -> impl Iterator<Item = &str> + '_ {
         self.variants()
-            .flat_map(|(m, _, _)| m.into_iter().map(|m| m.strip_suffix('?').unwrap_or(m)))
+            .flat_map(|(m, _, _)| m.into_iter().map(|m| m.name()))
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
     }
@@ -170,7 +170,9 @@ mod test {
             };
             let variants = s
                 .variants()
-                .map(|(m, v, _)| (m.into_iter().collect::<BTreeSet<_>>(), v))
+                .map(|(m, v, _)| {
+                    (m.into_iter().map(|m| m.as_str()).collect::<BTreeSet<_>>(), v)
+                })
                 .collect::<BTreeSet<_>>();
             let control = control
                 .iter()
@@ -178,6 +180,7 @@ mod test {
                     (
                         ModifierSet::from_raw_dotted(m)
                             .into_iter()
+                            .map(|m| m.as_str())
                             .collect::<BTreeSet<_>>(),
                         v,
                     )

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -17,34 +17,34 @@ anchor ⚓
 anger 💢
 ant 🐜
 apple
-  .green 🍏
+  .green? 🍏
   .red 🍎
 arm
-  .mech 🦾
+  .mech? 🦾
   .muscle 💪
   .selfie 🤳
 arrow
-  .r.filled ➡
-  .r.hook ↪
-  .r.soon 🔜
-  .l.filled ⬅
+  .r?.filled? ➡
+  .r?.hook ↪
+  .r?.soon 🔜
+  .l.filled? ⬅
   .l.hook ↩
-  .l.back 🔙
-  .l.end 🔚
-  .t.filled ⬆
-  .t.curve ⤴
-  .t.top 🔝
-  .b.filled ⬇
+  .l?.back 🔙
+  .l?.end 🔚
+  .t.filled? ⬆
+  .t?.curve ⤴
+  .t?.top 🔝
+  .b.filled? ⬇
   .b.curve ⤵
   .l.r ↔
-  .l.r.on 🔛
+  .l?.r?.on 🔛
   .t.b ↕
   .bl ↙
   .br ↘
   .tl ↖
   .tr ↗
 arrows
-  .cycle 🔄
+  .cycle? 🔄
 ast *
   .box ✳
 atm 🏧
@@ -65,7 +65,7 @@ baggageclaim 🛄
 baguette 🥖
 balloon 🎈
 ballot
-  .check ☑
+  .check? ☑
 ballotbox 🗳
 banana 🍌
 banjo 🪕
@@ -82,7 +82,7 @@ bathtub 🛀
 battery 🔋
   .low 🪫
 beach
-  .palm 🏝
+  .palm? 🏝
   .umbrella 🏖
 beads 📿
 beans 🫘
@@ -116,7 +116,7 @@ blowfish 🐡
 blueberries 🫐
 boar 🐗
 boat
-  .sail ⛵
+  .sail? ⛵
   .row 🚣
   .motor 🛥
   .speed 🚤
@@ -125,7 +125,7 @@ bolt 🔩
 bomb 💣
 bone 🦴
 book
-  .red 📕
+  .red? 📕
   .blue 📘
   .green 📗
   .orange 📙
@@ -138,7 +138,7 @@ bordercontrol 🛂
 bouquet 💐
 bow 🏹
 bowl
-  .spoon 🥣
+  .spoon? 🥣
   .steam 🍜
 bowling 🎳
 boxing 🥊
@@ -148,26 +148,26 @@ bread 🍞
 brick 🧱
 bride 👰
 bridge
-  .fog 🌁
+  .fog? 🌁
   .night 🌉
 briefcase 💼
 briefs 🩲
 brightness
-  .high 🔆
+  .high? 🔆
   .low 🔅
 broccoli 🥦
 broom 🧹
 brush 🖌
 bubble
-  .speech.r 💬
-  .speech.l 🗨
+  .speech?.r? 💬
+  .speech?.l 🗨
   .thought 💭
-  .anger.r 🗯
+  .anger.r? 🗯
 bubbles 🫧
 bubbletea 🧋
 bucket 🪣
 buffalo
-  .water 🐃
+  .water? 🐃
 bug 🐛
 builder 👷
 burger 🍔
@@ -183,7 +183,7 @@ button 🔲
   .alt 🔳
   .radio 🔘
 cabinet
-  .file 🗄
+  .file? 🗄
 cablecar 🚠
   .small 🚡
 cactus 🌵
@@ -199,7 +199,7 @@ camel 🐫
 camera 📷
   .flash 📸
   .movie 🎥
-  .movie.box 🎦
+  .movie?.box 🎦
   .video 📹
 camping 🏕
 can 🥫
@@ -215,37 +215,37 @@ car 🚗
   .rickshaw 🛺
   .suv 🚙
 card
-  .credit 💳
+  .credit? 💳
   .id 🪪
 cardindex 📇
 carrot 🥕
 cart 🛒
 cassette 📼
 castle
-  .eu 🏰
+  .eu? 🏰
   .jp 🏯
 cat 🐈
   .face 🐱
-  .face.angry 😾
-  .face.cry 😿
-  .face.heart 😻
-  .face.joy 😹
-  .face.kiss 😽
-  .face.laugh 😸
-  .face.shock 🙀
-  .face.smile 😺
-  .face.smirk 😼
+  .face?.angry 😾
+  .face?.cry 😿
+  .face?.heart 😻
+  .face?.joy 😹
+  .face?.kiss 😽
+  .face?.laugh 😸
+  .face?.shock 🙀
+  .face?.smile 😺
+  .face?.smirk 😼
 chain 🔗
 chains ⛓
 chair 🪑
 champagne 🍾
 chart
-  .bar 📊
+  .bar? 📊
   .up 📈
   .down 📉
-  .yen.up 💹
+  .yen.up? 💹
 checkmark
-  .heavy ✔
+  .heavy? ✔
   .box ✅
 cheese 🧀
 cherries 🍒
@@ -253,8 +253,8 @@ chess ♟
 chestnut 🌰
 chicken 🐔
   .baby 🐥
-  .baby.egg 🐣
-  .baby.head 🐤
+  .baby?.egg 🐣
+  .baby?.head 🐤
   .leg 🍗
   .male 🐓
 child 🧒
@@ -266,7 +266,7 @@ church ⛪
 cigarette 🚬
   .not 🚭
 circle
-  .black ⚫
+  .black? ⚫
   .blue 🔵
   .brown 🟤
   .green 🟢
@@ -288,8 +288,8 @@ clip 📎
 clipboard 📋
 clips 🖇
 clock
-  .one 🕐
-  .one.thirty 🕜
+  .one? 🕐
+  .one?.thirty 🕜
   .two 🕑
   .two.thirty 🕝
   .three 🕒
@@ -328,7 +328,7 @@ coat 🧥
   .lab 🥼
 cockroach 🪳
 cocktail
-  .martini 🍸
+  .martini? 🍸
   .tropical 🍹
 coconut 🥥
 coffee ☕
@@ -366,7 +366,7 @@ crutch 🩼
 crystal 🔮
 cucumber 🥒
 cup
-  .straw 🥤
+  .straw? 🥤
 cupcake 🧁
 curling 🥌
 curry 🍛
@@ -375,27 +375,27 @@ customs 🛃
 cutlery 🍴
 cyclone 🌀
 dancing
-  .man 🕺
+  .man? 🕺
   .woman 💃
   .women.bunny 👯
 darts 🎯
 dash
-  .wave.double 〰
+  .wave?.double? 〰
 deer 🦌
 desert 🏜
 detective 🕵
 diamond
-  .blue 🔷
-  .blue.small 🔹
+  .blue? 🔷
+  .blue?.small 🔹
   .orange 🔶
   .orange.small 🔸
   .dot 💠
 die 🎲
 dino
-  .pod 🦕
+  .pod? 🦕
   .rex 🦖
 disc
-  .cd 💿
+  .cd? 💿
   .dvd 📀
   .mini 💽
 discoball 🪩
@@ -411,7 +411,7 @@ donkey 🫏
 donut 🍩
 door 🚪
 dove
-  .peace 🕊
+  .peace? 🕊
 dragon 🐉
   .face 🐲
 dress 👗
@@ -428,7 +428,7 @@ ear 👂
   .aid 🦻
 egg 🥚
 eighteen
-  .not 🔞
+  .not? 🔞
 elephant 🐘
 elevator 🛗
 elf 🧝
@@ -442,9 +442,9 @@ extinguisher 🧯
 eye 👁
 eyes 👀
 face
-  .grin 😀
+  .grin? 😀
   .angry 😠
-  .angry.red 😡
+  .angry?.red 😡
   .anguish 😧
   .astonish 😲
   .bandage 🤕
@@ -457,7 +457,7 @@ face
   .cover 🤭
   .cowboy 🤠
   .cry 😭
-  .devil.smile 😈
+  .devil.smile? 😈
   .devil.frown 👿
   .diagonal 🫤
   .disguise 🥸
@@ -465,7 +465,7 @@ face
   .dizzy 😵
   .dotted 🫥
   .down 😞
-  .down.sweat 😓
+  .down?.sweat 😓
   .drool 🤤
   .explode 🤯
   .eyeroll 🙄
@@ -489,7 +489,7 @@ face
   .kiss 😗
   .kiss.smile 😙
   .kiss.heart 😘
-  .kiss.blush 😚
+  .kiss?.blush 😚
   .lick 😋
   .lie 🤥
   .mask 😷
@@ -520,7 +520,7 @@ face
   .smile.tear 🥲
   .smirk 😏
   .sneeze 🤧
-  .speak.not 🫢
+  .speak.not? 🫢
   .squint 😆
   .stars 🤩
   .straight 😑
@@ -558,7 +558,7 @@ faith
   .om 🕉
   .orthodox ☦
   .peace ☮
-  .star.dot 🔯
+  .star.dot? 🔯
   .worship 🛐
   .yinyang ☯
 falafel 🧆
@@ -566,14 +566,14 @@ family 👪
 fax 📠
 feather 🪶
 feeding
-  .breast 🤱
+  .breast? 🤱
 fencing 🤺
 ferriswheel 🎡
 filebox 🗃
 filedividers 🗂
 film 🎞
 finger
-  .r 👉
+  .r? 👉
   .l 👈
   .t 👆
   .t.alt ☝
@@ -582,7 +582,7 @@ finger
   .m 🖕
 fingerprint 🫆
 fingers
-  .cross 🤞
+  .cross? 🤞
   .pinch 🤌
   .snap 🫰
 fire 🔥
@@ -593,25 +593,25 @@ fish 🐟
   .tropical 🐠
 fishing 🎣
 fist
-  .front 👊
+  .front? 👊
   .r 🤜
   .l 🤛
   .raised ✊
 flag
-  .black 🏴
+  .black? 🏴
   .white 🏳
   .goal 🏁
   .golf ⛳
   .red 🚩
 flags
-  .jp.crossed 🎌
+  .jp?.crossed? 🎌
 flamingo 🦩
 flashlight 🔦
 flatbread 🫓
 fleur ⚜
 floppy 💾
 flower
-  .hibiscus 🌺
+  .hibiscus? 🌺
   .hyacinth 🪻
   .lotus 🪷
   .pink 🌸
@@ -637,7 +637,7 @@ free 🆓
 fries 🍟
 frisbee 🥏
 frog
-  .face 🐸
+  .face? 🐸
 fuelpump ⛽
 garlic 🧄
 gear ⚙
@@ -648,14 +648,14 @@ ginger 🫚
 giraffe 🦒
 girl 👧
 glass
-  .clink 🥂
+  .clink? 🥂
   .milk 🥛
   .pour 🫗
   .tumbler 🥃
 glasses 👓
   .sun 🕶
 globe
-  .am 🌎
+  .am? 🌎
   .as.au 🌏
   .eu.af 🌍
   .meridian 🌐
@@ -668,7 +668,7 @@ goose 🪿
 gorilla 🦍
 grapes 🍇
 guard
-  .man 💂
+  .man? 💂
 guitar 🎸
 gymnastics 🤸
 haircut 💇
@@ -678,10 +678,10 @@ hammer 🔨
   .wrench 🛠
 hamsa 🪬
 hamster
-  .face 🐹
+  .face? 🐹
 hand
-  .raised ✋
-  .raised.alt 🤚
+  .raised? ✋
+  .raised?.alt 🤚
   .r 🫱
   .l 🫲
   .t 🫴
@@ -692,7 +692,7 @@ hand
   .part 🖖
   .peace ✌
   .pinch 🤏
-  .pushing.l 🫷
+  .pushing.l? 🫷
   .pushing.r 🫸
   .rock 🤘
   .splay 🖐
@@ -706,7 +706,7 @@ handholding
   .woman.man 👫
   .woman.woman 👭
 hands
-  .folded 🙏
+  .folded? 🙏
   .palms 🤲
   .clap 👏
   .heart 🫶
@@ -716,7 +716,7 @@ hands
 harp 🪉
 hash #
 hat
-  .ribbon 👒
+  .ribbon? 👒
   .top 🎩
 headphone 🎧
 heart ❤
@@ -746,7 +746,7 @@ hedgehog 🦔
 helicopter 🚁
 helix 🧬
 helmet
-  .cross ⛑
+  .cross? ⛑
   .military 🪖
 hippo 🦛
 hockey 🏑
@@ -755,7 +755,7 @@ honey 🍯
 hongbao 🧧
 hook 🪝
 horn
-  .postal 📯
+  .postal? 📯
 horse 🐎
   .carousel 🎠
   .face 🐴
@@ -833,7 +833,7 @@ label 🏷
 lacrosse 🥍
 ladder 🪜
 lamp
-  .diya 🪔
+  .diya? 🪔
 laptop 💻
 a 🅰
 ab 🆎
@@ -841,9 +841,9 @@ b 🅱
 cl 🆑
 o 🅾
 leaf
-  .clover.three ☘
+  .clover.three? ☘
   .clover.four 🍀
-  .fall 🍂
+  .fall? 🍂
   .herb 🌿
   .maple 🍁
   .wind 🍃
@@ -853,7 +853,7 @@ leg 🦵
 lemon 🍋
 leopard 🐆
 letter
-  .love 💌
+  .love? 💌
 liberty 🗽
 lightbulb 💡
 lightning ⚡
@@ -875,21 +875,21 @@ lungs 🫁
 mage 🧙
 magnet 🧲
 magnify
-  .r 🔎
+  .r? 🔎
   .l 🔍
 mahjong
-  .dragon.red 🀄
+  .dragon?.red? 🀄
 mail ✉
   .arrow 📩
 mailbox
-  .closed.empty 📪
-  .closed.full 📫
-  .open.empty 📭
+  .closed?.empty? 📪
+  .closed?.full 📫
+  .open.empty? 📭
   .open.full 📬
 mammoth 🦣
 mango 🥭
 map
-  .world 🗺
+  .world? 🗺
   .jp 🗾
 maracas 🪇
 martialarts 🥋
@@ -899,7 +899,7 @@ matryoshka 🪆
 meat 🥩
   .bone 🍖
 medal
-  .first 🥇
+  .first? 🥇
   .second 🥈
   .third 🥉
   .sports 🏅
@@ -917,7 +917,7 @@ milkyway 🌌
 mirror 🪞
 mixer 🎛
 money
-  .bag 💰
+  .bag? 💰
   .dollar 💵
   .euro 💶
   .pound 💷
@@ -925,22 +925,22 @@ money
   .wings 💸
 monkey 🐒
   .face 🐵
-  .hear.not 🙉
-  .see.not 🙈
-  .speak.not 🙊
+  .hear.not? 🙉
+  .see.not? 🙈
+  .speak.not? 🙊
 moon
-  .crescent 🌙
+  .crescent? 🌙
   .full 🌕
-  .full.face 🌝
+  .full?.face 🌝
   .new 🌑
   .new.face 🌚
-  .wane.one 🌖
-  .wane.two 🌗
-  .wane.three.face 🌜
-  .wane.three 🌘
-  .wax.one 🌒
+  .wane.one? 🌖
+  .wane?.two 🌗
+  .wane.three?.face 🌜
+  .wane?.three 🌘
+  .wax.one? 🌒
   .wax.two 🌓
-  .wax.two.face 🌛
+  .wax.two?.face 🌛
   .wax.three 🌔
 moose 🫎
 mortarboard 🎓
@@ -962,13 +962,13 @@ museum 🏛
 mushroom 🍄
 musicalscore 🎼
 nails
-  .polish 💅
+  .polish? 💅
 namebadge 📛
 nazar 🧿
 necktie 👔
 needle 🪡
 nest
-  .empty 🪹
+  .empty? 🪹
   .eggs 🪺
 new 🆕
 newspaper 📰
@@ -1003,7 +1003,7 @@ page 📄
   .pencil 📝
 pager 📟
 pages
-  .tabs 📑
+  .tabs? 📑
 painting 🖼
 palette 🎨
 pancakes 🥞
@@ -1022,7 +1022,7 @@ pear 🍐
 pedestrian 🚶
   .not 🚷
 pen
-  .ball 🖊
+  .ball? 🖊
   .fountain 🖋
 pencil ✏
 penguin 🐧
@@ -1078,9 +1078,9 @@ planet 🪐
 plant 🪴
 plaster 🩹
 plate
-  .cutlery 🍽
+  .cutlery? 🍽
 playback
-  .down ⏬
+  .down? ⏬
   .eject ⏏
   .forward ⏩
   .pause ⏸
@@ -1096,14 +1096,14 @@ playback
   .toggle ⏯
   .up ⏫
 playingcard
-  .flower 🎴
+  .flower? 🎴
   .joker 🃏
 plunger 🪠
 policeofficer 👮
 poo 💩
 popcorn 🍿
 post
-  .eu 🏤
+  .eu? 🏤
   .jp 🏣
 postbox 📮
 potato 🥔
@@ -1114,12 +1114,12 @@ present 🎁
 pretzel 🥨
 printer 🖨
 prints
-  .foot 👣
+  .foot? 👣
   .paw 🐾
 prohibited 🚫
 projector 📽
 pumpkin
-  .lantern 🎃
+  .lantern? 🎃
 purse 👛
 quest ❓
   .white ❔
@@ -1162,7 +1162,7 @@ salad 🥗
 salt 🧂
 sandwich 🥪
 santa
-  .man 🎅
+  .man? 🎅
   .woman 🤶
 satdish 📡
 satellite 🛰
@@ -1183,13 +1183,13 @@ seedling 🌱
 shark 🦈
 sheep 🐑
 shell
-  .spiral 🐚
+  .spiral? 🐚
 shield 🛡
 ship 🚢
   .cruise 🛳
   .ferry ⛴
 shirt
-  .sports 🎽
+  .sports? 🎽
   .t 👕
 shoe 👞
   .ballet 🩰
@@ -1198,7 +1198,7 @@ shoe 👞
   .hike 🥾
   .ice ⛸
   .roller 🛼
-  .sandal.heel 👡
+  .sandal.heel? 👡
   .ski 🎿
   .sneaker 👟
   .tall 👢
@@ -1212,7 +1212,7 @@ shrimp 🦐
   .fried 🍤
 shrine ⛩
 sign
-  .crossing 🚸
+  .crossing? 🚸
   .stop 🛑
 silhouette 👤
   .double 👥
@@ -1221,7 +1221,7 @@ silhouette 👤
 siren 🚨
 skateboard 🛹
 skewer
-  .dango 🍡
+  .dango? 🍡
   .oden 🍢
 skiing ⛷
 skull 💀
@@ -1245,7 +1245,7 @@ sos 🆘
 soup 🍲
 spaghetti 🍝
 sparkle
-  .box ❇
+  .box? ❇
 sparkler 🎇
 sparkles ✨
 speaker 🔈
@@ -1259,10 +1259,10 @@ splatter 🫟
 sponge 🧽
 spoon 🥄
 square
-  .black ⬛
-  .black.tiny ▪
-  .black.small ◾
-  .black.medium ◼
+  .black? ⬛
+  .black?.tiny ▪
+  .black?.small ◾
+  .black?.medium ◼
   .white ⬜
   .white.tiny ▫
   .white.small ◽
@@ -1283,7 +1283,7 @@ star ⭐
   .shoot 🌠
 stethoscope 🩺
 store
-  .big 🏬
+  .big? 🏬
   .small 🏪
 strawberry 🍓
 suit
@@ -1328,10 +1328,10 @@ testtube 🧪
 thermometer 🌡
 thread 🧵
 thumb
-  .up 👍
+  .up? 👍
   .down 👎
 ticket
-  .event 🎟
+  .event? 🎟
   .travel 🎫
 tiger 🐅
   .face 🐯
@@ -1346,11 +1346,11 @@ tooth 🦷
 toothbrush 🪥
 tornado 🌪
 tower
-  .tokyo 🗼
+  .tokyo? 🗼
 trackball 🖲
 tractor 🚜
 trafficlight
-  .v 🚦
+  .v? 🚦
   .h 🚥
 train 🚆
   .car 🚃
@@ -1359,7 +1359,7 @@ train 🚆
   .mono 🚝
   .mountain 🚞
   .speed 🚄
-  .speed.bullet 🚅
+  .speed?.bullet 🚅
   .steam 🚂
   .stop 🚉
   .suspend 🚟
@@ -1367,21 +1367,21 @@ train 🚆
   .tram.car 🚋
 transgender ⚧
 tray
-  .inbox 📥
+  .inbox? 📥
   .mail 📨
   .outbox 📤
 tree
-  .deciduous 🌳
+  .deciduous? 🌳
   .evergreen 🌲
   .leafless 🪾
   .palm 🌴
   .xmas 🎄
 triangle
-  .r ▶
+  .r? ▶
   .l ◀
   .t 🔼
   .b 🔽
-  .t.red 🔺
+  .t?.red 🔺
   .b.red 🔻
 trident 🔱
 troll 🧌
@@ -1395,7 +1395,7 @@ turtle 🐢
 tv 📺
 ufo 🛸
 umbrella
-  .open ☂
+  .open? ☂
   .closed 🌂
   .rain ☔
   .sun ⛱
@@ -1445,7 +1445,7 @@ yarn 🧶
 yoyo 🪀
 zebra 🦓
 zodiac
-  .aquarius ♒
+  .aquarius? ♒
   .aries ♈
   .cancer ♋
   .capri ♑

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -23,53 +23,53 @@ space \u{20}
 
 // Delimiters.
 paren
-  .l (
-  .l.double ⦅
+  .l? (
+  .l?.double ⦅
   .r )
   .r.double ⦆
   .t ⏜
   .b ⏝
 brace
-  .l \u{7B}
-  .l.double ⦃
+  .l? \u{7B}
+  .l?.double ⦃
   .r \u{7D}
   .r.double ⦄
   .t ⏞
   .b ⏟
 bracket
-  .l [
-  .l.double ⟦
+  .l? [
+  .l?.double ⟦
   .r ]
   .r.double ⟧
   .t ⎴
   .b ⎵
 shell
-  .l ❲
-  .l.double ⟬
+  .l? ❲
+  .l?.double ⟬
   .r ❳
   .r.double ⟭
   .t ⏠
   .b ⏡
 bar
-  .v |
-  .v.double ‖
-  .v.triple ⦀
-  .v.broken ¦
-  .v.o ⦶
+  .v? |
+  .v?.double ‖
+  .v?.triple ⦀
+  .v?.broken ¦
+  .v?.o ⦶
   @deprecated: `bar.v.circle` is deprecated, use `bar.v.o` instead
-  .v.circle ⦶
+  .v?.circle ⦶
   .h ―
 fence
-  .l ⧘
-  .l.double ⧚
+  .l? ⧘
+  .l?.double ⧚
   .r ⧙
   .r.double ⧛
   .dotted ⦙
 angle ∠
   .l ⟨
-  .l.curly ⧼
-  .l.dot ⦑
-  .l.double ⟪
+  .l?.curly ⧼
+  .l?.dot ⦑
+  .l?.double ⟪
   .r ⟩
   .r.curly ⧽
   .r.dot ⦒
@@ -83,7 +83,7 @@ angle ∠
   .right.rev ⯾
   .right.arc ⊾
   .right.dot ⦝
-  .right.sq ⦜
+  .right?.sq ⦜
   .s ⦞
   .spatial ⟀
   .spheric ∢
@@ -92,18 +92,18 @@ angle ∠
   @deprecated: `angle.spheric.top` is deprecated, use `angle.spheric.t` instead
   .spheric.top ⦡
 ceil
-  .l ⌈
+  .l? ⌈
   .r ⌉
 floor
-  .l ⌊
+  .l? ⌊
   .r ⌋
 
 // Punctuation.
 amp &
   .inv ⅋
 ast
-  .op ∗
-  .op.o ⊛
+  .op? ∗
+  .op?.o ⊛
   .basic *
   .low ⁎
   .double ⁑
@@ -137,7 +137,7 @@ dagger †
   .r ⸷
   .inv ⸸
 dash
-  .en –
+  .en? –
   .em —
   .em.two ⸺
   .em.three ⸻
@@ -149,7 +149,7 @@ dash
   .circle ⊝
   .wave.double 〰
 dot
-  .op ⋅
+  .op? ⋅
   .basic \u{2E}
   .c ·
   .o ⊙
@@ -194,13 +194,13 @@ slash /
   .triple ⫻
   .big ⧸
 dots
-  .h.c ⋯
-  .h …
+  .h? …
+  .h?.c ⋯
   .v ⋮
   .down ⋱
   .up ⋰
 tilde
-  .op ∼
+  .op? ∼
   .basic ~
   .dot ⩪
   .eq ≃
@@ -225,19 +225,19 @@ diaer ¨
 grave `
 macron ¯
 quote
-  .double "
+  .double? "
   .single '
-  .l.double “
+  .l.double? “
   .l.single ‘
-  .r.double ”
+  .r.double? ”
   .r.single ’
-  .angle.l.double «
-  .angle.l.single ‹
-  .angle.r.double »
+  .angle.l?.double? «
+  .angle.l?.single ‹
+  .angle.r.double? »
   .angle.r.single ›
-  .high.double ‟
+  .high.double? ‟
   .high.single ‛
-  .low.double „
+  .low.double? „
   .low.single ‚
 prime ′
   .rev ‵
@@ -290,7 +290,7 @@ times ×
   @deprecated: `times.circle.big` is deprecated, use `times.o.big` instead
   .circle.big ⨂
   .div ⋇
-  .three.l ⋋
+  .three.l? ⋋
   .three.r ⋌
   .l ⋉
   .r ⋊
@@ -425,13 +425,13 @@ asymp ≍
 
 // Set theory.
 emptyset ∅
-  .arrow.r ⦳
+  .arrow.r? ⦳
   .arrow.l ⦴
   .bar ⦱
   .circle ⦲
   .rev ⦰
 nothing ∅
-  .arrow.r ⦳
+  .arrow.r? ⦳
   .arrow.l ⦴
   .bar ⦱
   .circle ⦲
@@ -513,7 +513,7 @@ sum ∑
 product ∏
   .co ∐
 integral ∫
-  .arrow.hook ⨗
+  .arrow.hook? ⨗
   .ccw ⨑
   .cont ∮
   .cont.ccw ∳
@@ -595,7 +595,7 @@ parallel ∥
   .equiv ⩨
   .not ∦
   .slanted.eq ⧣
-  .slanted.eq.tilde ⧤
+  .slanted?.eq.tilde ⧤
   .slanted.equiv ⧥
   .tilde ⫳
 perp ⟂
@@ -627,12 +627,12 @@ join ⨝
   .l ⟕
   .l.r ⟗
 hourglass
-  .stroked ⧖
+  .stroked? ⧖
   .filled ⧗
 degree °
 smash ⨳
 power
-  .standby ⏻
+  .standby? ⏻
   .on ⏽
   .off ⭘
   .on.off ⏼
@@ -668,7 +668,7 @@ pound £
 riel ៛
 ruble ₽
 rupee
-  .indian ₹
+  .indian? ₹
   .generic ₨
   .tamil ௹
   .wancho 𞋿
@@ -711,18 +711,18 @@ trademark ™
   .service ℠
 maltese ✠
 suit
-  .club.filled ♣
+  .club.filled? ♣
   .club.stroked ♧
-  .diamond.filled ♦
+  .diamond.filled? ♦
   .diamond.stroked ♢
-  .heart.filled ♥
+  .heart.filled? ♥
   .heart.stroked ♡
-  .spade.filled ♠
+  .spade.filled? ♠
   .spade.stroked ♤
 
 // Music.
 note
-  .up 🎜
+  .up? 🎜
   .down 🎝
   .whole 𝅝
   .half 𝅗𝅥
@@ -736,7 +736,7 @@ note
   .grace 𝆕
   .grace.slash 𝆔
 rest
-  .whole 𝄻
+  .whole? 𝄻
   .multiple 𝄺
   .multiple.measure 𝄩
   .half 𝄼
@@ -769,10 +769,10 @@ bullet •
   .l ⁌
   .r ⁍
 circle
-  .stroked ○
-  .stroked.tiny ∘
-  .stroked.small ⚬
-  .stroked.big ◯
+  .stroked? ○
+  .stroked?.tiny ∘
+  .stroked?.small ⚬
+  .stroked?.big ◯
   .filled ●
   .filled.tiny ⦁
   .filled.small ∙
@@ -781,27 +781,27 @@ circle
   @deprecated: `circle.nested` is deprecated, use `compose.o` instead
   .nested ⊚
 ellipse
-  .stroked.h ⬭
-  .stroked.v ⬯
-  .filled.h ⬬
+  .stroked?.h? ⬭
+  .stroked?.v ⬯
+  .filled.h? ⬬
   .filled.v ⬮
 triangle
-  .stroked.t △
-  .stroked.b ▽
-  .stroked.r ▷
-  .stroked.l ◁
-  .stroked.bl ◺
-  .stroked.br ◿
-  .stroked.tl ◸
-  .stroked.tr ◹
-  .stroked.small.t ▵
-  .stroked.small.b ▿
-  .stroked.small.r ▹
-  .stroked.small.l ◃
-  .stroked.rounded 🛆
-  .stroked.nested ⟁
-  .stroked.dot ◬
-  .filled.t ▲
+  .stroked?.t? △
+  .stroked?.b ▽
+  .stroked?.r ▷
+  .stroked?.l ◁
+  .stroked?.bl ◺
+  .stroked?.br ◿
+  .stroked?.tl ◸
+  .stroked?.tr ◹
+  .stroked?.small.t? ▵
+  .stroked?.small.b ▿
+  .stroked?.small.r ▹
+  .stroked?.small.l ◃
+  .stroked?.rounded 🛆
+  .stroked?.nested ⟁
+  .stroked?.dot ◬
+  .filled.t? ▲
   .filled.b ▼
   .filled.r ▶
   .filled.l ◀
@@ -809,98 +809,98 @@ triangle
   .filled.br ◢
   .filled.tl ◤
   .filled.tr ◥
-  .filled.small.t ▴
+  .filled.small.t? ▴
   .filled.small.b ▾
   .filled.small.r ▸
   .filled.small.l ◂
 square
-  .stroked □
-  .stroked.tiny ▫
-  .stroked.small ◽
-  .stroked.medium ◻
-  .stroked.big ⬜
-  .stroked.dotted ⬚
-  .stroked.rounded ▢
+  .stroked? □
+  .stroked?.tiny ▫
+  .stroked?.small ◽
+  .stroked?.medium ◻
+  .stroked?.big ⬜
+  .stroked?.dotted ⬚
+  .stroked?.rounded ▢
   .filled ■
   .filled.tiny ▪
   .filled.small ◾
   .filled.medium ◼
   .filled.big ⬛
 rect
-  .stroked.h ▭
-  .stroked.v ▯
-  .filled.h ▬
+  .stroked?.h? ▭
+  .stroked?.v ▯
+  .filled.h? ▬
   .filled.v ▮
 penta
-  .stroked ⬠
+  .stroked? ⬠
   .filled ⬟
 hexa
-  .stroked ⬡
+  .stroked? ⬡
   .filled ⬢
 diamond
-  .stroked ◇
-  .stroked.small ⋄
-  .stroked.medium ⬦
-  .stroked.dot ⟐
+  .stroked? ◇
+  .stroked?.small ⋄
+  .stroked?.medium ⬦
+  .stroked?.dot ⟐
   .filled ◆
   .filled.medium ⬥
   .filled.small ⬩
 lozenge
-  .stroked ◊
-  .stroked.small ⬫
-  .stroked.medium ⬨
+  .stroked? ◊
+  .stroked?.small ⬫
+  .stroked?.medium ⬨
   .filled ⧫
   .filled.small ⬪
   .filled.medium ⬧
 parallelogram
-  .stroked ▱
+  .stroked? ▱
   .filled ▰
 star
-  .op ⋆
+  .op? ⋆
   .stroked ☆
   .filled ★
 
 // Arrows, harpoons, and tacks.
 arrow
-  .r →
-  .r.long.bar ⟼
-  .r.bar ↦
-  .r.curve ⤷
-  .r.turn ⮎
-  .r.dashed ⇢
-  .r.dotted ⤑
-  .r.double ⇒
-  .r.double.bar ⤇
-  .r.double.long ⟹
-  .r.double.long.bar ⟾
-  .r.double.not ⇏
-  .r.double.struck ⤃
-  .r.filled ➡
-  .r.hook ↪
-  .r.long ⟶
-  .r.long.squiggly ⟿
-  .r.loop ↬
-  .r.not ↛
-  .r.quad ⭆
-  .r.squiggly ⇝
-  .r.stop ⇥
-  .r.stroked ⇨
-  .r.struck ⇸
-  .r.dstruck ⇻
-  .r.tail ↣
-  .r.tail.struck ⤔
-  .r.tail.dstruck ⤕
-  .r.tilde ⥲
-  .r.triple ⇛
-  .r.twohead ↠
-  .r.twohead.bar ⤅
-  .r.twohead.struck ⤀
-  .r.twohead.dstruck ⤁
-  .r.twohead.tail ⤖
-  .r.twohead.tail.struck ⤗
-  .r.twohead.tail.dstruck ⤘
-  .r.open ⇾
-  .r.wave ↝
+  .r? →
+  .r?.long.bar ⟼
+  .r?.bar ↦
+  .r?.curve ⤷
+  .r?.turn ⮎
+  .r?.dashed ⇢
+  .r?.dotted ⤑
+  .r?.double ⇒
+  .r?.double.bar ⤇
+  .r?.double.long ⟹
+  .r?.double.long.bar ⟾
+  .r?.double.not ⇏
+  .r?.double.struck ⤃
+  .r?.filled ➡
+  .r?.hook ↪
+  .r?.long ⟶
+  .r?.long.squiggly ⟿
+  .r?.loop ↬
+  .r?.not ↛
+  .r?.quad ⭆
+  .r?.squiggly ⇝
+  .r?.stop ⇥
+  .r?.stroked ⇨
+  .r?.struck ⇸
+  .r?.dstruck ⇻
+  .r?.tail ↣
+  .r?.tail.struck ⤔
+  .r?.tail.dstruck ⤕
+  .r?.tilde ⥲
+  .r?.triple ⇛
+  .r?.twohead ↠
+  .r?.twohead.bar ⤅
+  .r?.twohead.struck ⤀
+  .r?.twohead.dstruck ⤁
+  .r?.twohead.tail ⤖
+  .r?.twohead.tail.struck ⤗
+  .r?.twohead.tail.dstruck ⤘
+  .r?.open ⇾
+  .r?.wave ↝
   .l ←
   .l.bar ↤
   .l.curve ⤶
@@ -1013,7 +1013,7 @@ arrow
   .cw.half ↷
   .zigzag ↯
 arrows
-  .rr ⇉
+  .rr? ⇉
   .ll ⇇
   .tt ⇈
   .bb ⇊
@@ -1025,12 +1025,12 @@ arrows
   .rrr ⇶
   .lll ⬱
 arrowhead
-  .t ⌃
+  .t? ⌃
   .b ⌄
 harpoon
-  .rt ⇀
-  .rt.bar ⥛
-  .rt.stop ⥓
+  .rt? ⇀
+  .rt?.bar ⥛
+  .rt?.stop ⥓
   .rb ⇁
   .rb.bar ⥟
   .rb.stop ⥗
@@ -1061,7 +1061,7 @@ harpoon
   .tl.br ⥍
   .tr.bl ⥌
 harpoons
-  .rtrb ⥤
+  .rtrb? ⥤
   .blbr ⥥
   .bltr ⥯
   .lbrb ⥧
@@ -1074,18 +1074,18 @@ harpoons
   .tlbr ⥮
   .tltr ⥣
 tack
-  .r ⊢
-  .r.not ⊬
-  .r.long ⟝
-  .r.short ⊦
-  .r.double ⊨
-  .r.double.not ⊭
+  .r? ⊢
+  .r?.not ⊬
+  .r?.long ⟝
+  .r?.short ⊦
+  .r?.double ⊨
+  .r?.double.not ⊭
   .l ⊣
   .l.long ⟞
   .l.short ⫞
   .l.double ⫤
   .t ⊥
-  .t.big ⟘
+  .t?.big ⟘
   .t.double ⫫
   .t.short ⫠
   .b ⊤
@@ -1103,7 +1103,7 @@ delta δ
 digamma ϝ
 epsilon ε
   .alt ϵ
-  .alt.rev ϶
+  .alt?.rev ϶
 eta η
 gamma γ
 iota ι
@@ -1226,23 +1226,23 @@ planck ħ
 Re ℜ
 Im ℑ
 dotless
-  .i ı
+  .i? ı
   .j ȷ
 
 // Miscellany.
 die
-  .six ⚅
+  .six? ⚅
   .five ⚄
   .four ⚃
   .three ⚂
   .two ⚁
   .one ⚀
 errorbar
-  .square.stroked ⧮
-  .square.filled ⧯
-  .diamond.stroked ⧰
+  .square?.stroked? ⧮
+  .square?.filled ⧯
+  .diamond.stroked? ⧰
   .diamond.filled ⧱
-  .circle.stroked ⧲
+  .circle.stroked? ⧲
   .circle.filled ⧳
 
 gender {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -108,9 +108,7 @@ impl<S: Deref<Target = str>> ModifierSet<S> {
         let mut best_score = None;
 
         // Find the best table entry with this name.
-        for candidate in variants.filter(|(set, _)| {
-            set.required_is_subset(self.as_deref()) && self.is_subset(*set)
-        }) {
+        for candidate in variants.filter(|(set, _)| self.is_candidate(*set)) {
             let mut matching = 0;
             let mut total = 0;
             for modifier in candidate.0.iter() {
@@ -139,7 +137,13 @@ impl<S: Deref<Target = str>> ModifierSet<S> {
     /// Whether all *non-optional* modifiers in `self` are also present in `other`,
     /// optional or not.
     pub fn required_is_subset(&self, other: ModifierSet<&str>) -> bool {
-        self.iter().filter(|m| !m.is_optional()).all(|m| other.contains(m.as_str()))
+        self.iter()
+            .filter(|m| !m.is_optional())
+            .all(|m| other.contains(m.as_str()))
+    }
+
+    pub(crate) fn is_candidate(&self, other: ModifierSet<&str>) -> bool {
+        other.required_is_subset(self.as_deref()) && self.is_subset(other)
     }
 }
 


### PR DESCRIPTION
Closes #51.

This is mostly done, but there are some unresolved questions and some issues and it still needs some finishing touches like documentation, which is why it's a draft for now.

This is also a breaking change since it changes the way `ModifierSet` works, so I should probably remember to bump the version in `Cargo.toml` before we merge this.

# Changes to observable syntax
The way I've implemented it, the `modifier?` syntax applies directly in the `ModifierSet`, so it would be exposed to the users in typst too. (Or typst would have to do some extra sanitizing).

And also, it's not really clear how this whole new resolution algorithm would interact with user-defined symbols from typst: I've kept the code in `best_match_in` mostly the same for now, but we could strip it down way more if the match was actually guaranteed to be unique. (But of course, this may not be true for user-defined symbols.)

# Changes to variant resolution
I have another branch where I wrote some ad-hoc code (mostly identical to what is now the `no_overlap` test) to brute-force check every possible modifier set for every symbol and generate a list of which ones differ between the old algorithm and the new one.

This is that list:
<details>
<pre><code>emoji.arrow : Some(("↙", None)) => Some(("➡", None))
emoji.bubble : Some(("💭", None)) => Some(("💬", None))
emoji.cloud.hidden : Some(("🌥", None)) => None
emoji.dancing.bunny : Some(("👯", None)) => None
emoji.dancing.women : Some(("👯", None)) => None
emoji.face.not : Some(("🫢", None)) => None
emoji.face.slight : Some(("🙁", None)) => None
emoji.face.withheld : Some(("🥹", None)) => None
emoji.faith : Some(("✝", None)) => None
emoji.faith.dot : Some(("🔯", None)) => None
emoji.finger.alt : Some(("☝", None)) => None
emoji.globe.af : Some(("🌍", None)) => None
emoji.globe.as : Some(("🌏", None)) => None
emoji.globe.au : Some(("🌏", None)) => None
emoji.globe.eu : Some(("🌍", None)) => None
emoji.handholding : Some(("👬", None)) => None
emoji.leaf.four : Some(("🍀", None)) => None
emoji.leaf.three : Some(("☘", None)) => None
emoji.monkey.not : Some(("🙉", None)) => None
emoji.moon.one : Some(("🌖", None)) => None
emoji.moon.face.three : Some(("🌜", None)) => None
emoji.moon.face.two : Some(("🌛", None)) => None
emoji.playback.once : Some(("🔂", None)) => None
emoji.playback.v : Some(("🔃", None)) => None
emoji.suit : Some(("♣", None)) => None
sym.angle.t : Some(("⦡", None)) => None
sym.angle.top : Some(("⦡", Some("`angle.spheric.top` is deprecated, use `angle.spheric.t` instead"))) => None
sym.arrow.half : Some(("↶", None)) => None
sym.arrows.stop : Some(("↹", None)) => None
sym.ballot.heavy : Some(("🗹", None)) => None
sym.colon.op : Some(("⫶", None)) => None
sym.dash.double : Some(("〰", None)) => None
sym.dash.three : Some(("⸻", None)) => None
sym.dash.two : Some(("⸺", None)) => None
sym.divides.rev : Some(("⫮", None)) => None
sym.dot.big : Some(("⨀", None)) => None
sym.emptyset.l : Some(("⦴", None)) => None
sym.emptyset.r : Some(("⦳", None)) => None
sym.eq.down : Some(("≒", None)) => None
sym.eq.up : Some(("≓", None)) => None
sym.gender.male.r : Some(("⚩", None)) => None
sym.gender.male.t : Some(("⚨", None)) => None
sym.gt.nested : Some(("⫸", None)) => None
sym.gt.slant : Some(("⩾", None)) => None
sym.integral.hook : Some(("⨗", None)) => None
sym.lt.nested : Some(("⫷", None)) => None
sym.lt.slant : Some(("⩽", None)) => None
sym.note.alt : Some(("♩", None)) => None
sym.note.beamed : Some(("♫", None)) => None
sym.note.slash : Some(("𝆔", None)) => None
sym.nothing.l : Some(("⦴", None)) => None
sym.nothing.r : Some(("⦳", None)) => None
sym.parallel.slanted : Some(("⧣", None)) => None
sym.parallel.slanted.tilde : Some(("⧤", None)) => None
sym.plus.arrow : Some(("⟴", None)) => None
sym.plus.big : Some(("⨁", None)) => None
sym.prec.curly : Some(("≼", None)) => None
sym.prec.curly.not : Some(("⋠", None)) => None
sym.prec.eq.not : Some(("⋠", None)) => None
sym.rest.measure : Some(("𝄩", None)) => None
sym.space.narrow : Some(("\u{202f}", None)) => None
sym.subset.not.sq : Some(("⋢", None)) => None
sym.succ.curly : Some(("≽", None)) => None
sym.succ.curly.not : Some(("⋡", None)) => None
sym.succ.eq.not : Some(("⋡", None)) => None
sym.suit : Some(("♣", None)) => None
sym.suit.filled : Some(("♣", None)) => None
sym.suit.stroked : Some(("♧", None)) => None
sym.supset.not.sq : Some(("⋣", None)) => None</code></pre>
</details>
Most of these should be net positives, but there are also some cases like <code>emoji.globe</code> where a variant has two optional modifiers, of which at least one needs to be present since it is not the default variant. This could in theory be encoded by duplicating the variant, but that'd be observable in the repr and also a bit hacky, so I haven't done it for now.

# Other stuff
I have some other minor things I'd like to say, but I'm too tired now, so I'll add them later.