### PR TITLE
`angle.oblique` should be `angle.obtuse`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -77,6 +77,8 @@ angle ∠
   .acute ⦟
   .arc ∡
   .arc.rev ⦛
+  .obtuse ⦦
+  @deprecated: `angle.oblique` is deprecated, use `angle.obtuse` instead
   .oblique ⦦
   .rev ⦣
   .right ∟


### PR DESCRIPTION
While oblique can apparently be used to refer to any angle that's not right, that's clearly not the intended meaning here. This is specifically an obtuse angle (that is, larger than 90 degrees).