### PR TITLE
Add missing arc modifier to `angle.right.dot`, rename `angle.right.sq`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -83,7 +83,9 @@ angle ∠
   .right.rev ⯾
   .right.arc ⊾
   .right.arc.dot ⦝
-  .right.arc.sq ⦜
+  .right.square ⦜
+  @deprecated: `angle.right.sq` is deprecated, use `angle.right.square` instead
+  .right.sq ⦜
   .s ⦞
   .spatial ⟀
   .spheric ∢

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -82,8 +82,8 @@ angle ∠
   .right ∟
   .right.rev ⯾
   .right.arc ⊾
-  .right.dot ⦝
-  .right.sq ⦜
+  .right.arc.dot ⦝
+  .right.arc.sq ⦜
   .s ⦞
   .spatial ⟀
   .spheric ∢


### PR DESCRIPTION
⦝ is specifically ⊾ with a dot, and `.sq` should mean a "squarified" version of a symbol (as opposed to `.square`)

Alternatively we could rename `angle.right.sq` to `angle.right.square` instead, but that would be a breaking change.