### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Modifiers are order-independent, so the latter can also be referred to as `arrow
 Additionally, not all modifiers have to be specified, in which case the best match[^match]
 will be taken. For example, `⇒` can also be referred to as `arrow.double`.
 Groups of related symbols are collected into *modules*. Modules can also contain other modules.
-Codex exports two top-level modules: `sym` for for text-style symbols and `emoji` for emoji;
+Codex exports two top-level modules: `sym` for text-style symbols and `emoji` for emoji;
 Their source code is found in `src/modules/`.
 
 If you need help with a contribution, you can also ask us [on Discord](https://discord.com/channels/1054443721975922748/1277628305142452306).


### PR DESCRIPTION
As mentioned in https://github.com/typst/codex/pull/110#issuecomment-3038954763.

These conventions are clearly contributing guidelines, so I went with `CONTRIBUTING.md` for the file name. That way we can also add other contributing guidelines in the future, if we want to.

If you want to reword something or add other conventions that I may have missed, don't hesitate to leave a comment.

From my side, there's only one unresolved question left here (which I also left as a TODO comment in the file itself), namely whether we want to write something about when we choose e.g. `.t.r` over `.tr` for corners (cf. https://github.com/typst/codex/pull/100).