### PR TITLE
Make some deprecation warnings more generic

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -27,24 +27,24 @@ paren
   .l.flat ⟮
   .l.closed ⦇
   .l.stroked ⦅
-  @deprecated: `paren.l.double` is deprecated, use `paren.l.stroked` instead
+  @deprecated: `paren.double` is deprecated, use `paren.stroked` instead
   .l.double ⦅
   .r )
   .r.flat ⟯
   .r.closed ⦈
   .r.stroked ⦆
-  @deprecated: `paren.r.double` is deprecated, use `paren.r.stroked` instead
+  @deprecated: `paren.double` is deprecated, use `paren.stroked` instead
   .r.double ⦆
   .t ⏜
   .b ⏝
 brace
   .l \u{7B}
   .l.stroked ⦃
-  @deprecated: `brace.l.double` is deprecated, use `brace.l.stroked` instead
+  @deprecated: `brace.double` is deprecated, use `brace.stroked` instead
   .l.double ⦃
   .r \u{7D}
   .r.stroked ⦄
-  @deprecated: `brace.r.double` is deprecated, use `brace.r.stroked` instead
+  @deprecated: `brace.double` is deprecated, use `brace.stroked` instead
   .r.double ⦄
   .t ⏞
   .b ⏟
@@ -53,13 +53,13 @@ bracket
   .l.tick.t ⦍
   .l.tick.b ⦏
   .l.stroked ⟦
-  @deprecated: `bracket.l.double` is deprecated, use `bracket.l.stroked` instead
+  @deprecated: `bracket.double` is deprecated, use `bracket.stroked` instead
   .l.double ⟦
   .r ]
   .r.tick.t ⦐
   .r.tick.b ⦎
   .r.stroked ⟧
-  @deprecated: `bracket.r.double` is deprecated, use `bracket.r.stroked` instead
+  @deprecated: `bracket.double` is deprecated, use `bracket.stroked` instead
   .r.double ⟧
   .t ⎴
   .b ⎵
@@ -67,12 +67,12 @@ shell
   .l ❲
   .l.stroked ⟬
   .l.filled ⦗
-  @deprecated: `shell.l.double` is deprecated, use `shell.l.stroked` instead
+  @deprecated: `shell.double` is deprecated, use `shell.stroked` instead
   .l.double ⟬
   .r ❳
   .r.stroked ⟭
   .r.filled ⦘
-  @deprecated: `shell.r.double` is deprecated, use `shell.r.stroked` instead
+  @deprecated: `shell.double` is deprecated, use `shell.stroked` instead
   .r.double ⟭
   .t ⏠
   .b ⏡
@@ -88,7 +88,7 @@ bar
   .v.triple ⦀
   .v.broken ¦
   .v.o ⦶
-  @deprecated: `bar.v.circle` is deprecated, use `bar.v.o` instead
+  @deprecated: `bar.circle` is deprecated, use `bar.o` instead
   .v.circle ⦶
   .h ―
 fence
@@ -257,13 +257,13 @@ quote
   .chevron.l.single ‹
   .chevron.r.double »
   .chevron.r.single ›
-  @deprecated: `quote.angle.l.double` is deprecated, use `quote.chevron.l.double` instead
+  @deprecated: `quote.angle` is deprecated, use `quote.chevron` instead
   .angle.l.double «
-  @deprecated: `quote.angle.l.single` is deprecated, use `quote.chevron.l.single` instead
+  @deprecated: `quote.angle` is deprecated, use `quote.chevron` instead
   .angle.l.single ‹
-  @deprecated: `quote.angle.r.double` is deprecated, use `quote.chevron.r.double` instead
+  @deprecated: `quote.angle` is deprecated, use `quote.chevron` instead
   .angle.r.double »
-  @deprecated: `quote.angle.r.single` is deprecated, use `quote.chevron.r.single` instead
+  @deprecated: `quote.angle` is deprecated, use `quote.chevron` instead
   .angle.r.single ›
   .high.double ‟
   .high.single ‛
@@ -288,9 +288,9 @@ plus +
   .o.big ⨁
   @deprecated: `plus.circle` is deprecated, use `plus.o` instead
   .circle ⊕
-  @deprecated: `plus.circle.arrow` is deprecated, use `plus.o.arrow` instead
+  @deprecated: `plus.circle` is deprecated, use `plus.o` instead
   .circle.arrow ⟴
-  @deprecated: `plus.circle.big` is deprecated, use `plus.o.big` instead
+  @deprecated: `plus.circle` is deprecated, use `plus.o` instead
   .circle.big ⨁
   .dot ∔
   .double ⧺
@@ -323,7 +323,7 @@ times ×
   .o.big ⨂
   @deprecated: `times.circle` is deprecated, use `times.o` instead
   .circle ⊗
-  @deprecated: `times.circle.big` is deprecated, use `times.o.big` instead
+  @deprecated: `times.circle` is deprecated, use `times.o` instead
   .circle.big ⨂
   .div ⋇
   .three.l ⋋
@@ -624,19 +624,19 @@ wreath ≀
 angle ∠
   @deprecated: `angle.l` is deprecated, use `chevron.l` instead
   .l ⟨
-  @deprecated: `angle.l.curly` is deprecated, use `chevron.l.curly` instead
+  @deprecated: `angle.l` is deprecated, use `chevron.l` instead
   .l.curly ⧼
-  @deprecated: `angle.l.dot` is deprecated, use `chevron.l.dot` instead
+  @deprecated: `angle.l` is deprecated, use `chevron.l` instead
   .l.dot ⦑
-  @deprecated: `angle.l.double` is deprecated, use `chevron.l.double` instead
+  @deprecated: `angle.l` is deprecated, use `chevron.l` instead
   .l.double ⟪
   @deprecated: `angle.r` is deprecated, use `chevron.r` instead
   .r ⟩
-  @deprecated: `angle.r.curly` is deprecated, use `chevron.r.curly` instead
+  @deprecated: `angle.r` is deprecated, use `chevron.r` instead
   .r.curly ⧽
-  @deprecated: `angle.r.dot` is deprecated, use `chevron.r.dot` instead
+  @deprecated: `angle.r` is deprecated, use `chevron.r` instead
   .r.dot ⦒
-  @deprecated: `angle.r.double` is deprecated, use `chevron.r.double` instead
+  @deprecated: `angle.r` is deprecated, use `chevron.r` instead
   .r.double ⟫
   .acute ⦟
   .arc ∡


### PR DESCRIPTION
For instance, the `paren.l.double` can also trigger from just `paren.double` and even `paren.double.r` (because it goes through the intermediate `paren.double`), so the more generic message is more helpful.

In Typst, this now gives the following output (together with the new deduplication strategy discussed in Discord):
```
warning: `ast.small` is deprecated (CJK compatibility character), use ﹡ or `\u{fe61}` instead
  ┌─ hi.typ:2:24
  │
2 │ $ bracket.stroked.l ast.small bracket.double.r $
  │                         ^^^^^

warning: `bracket.double` is deprecated, use `bracket.stroked` instead
  ┌─ hi.typ:2:38
  │
2 │ $ bracket.stroked.l ast.small bracket.double.r $
  │                                       ^^^^^^
```

I've opted to only apply this change when the modifier is sensible without the other modifiers (e.g. `paren.double` is perfectly legitimate). I've not done it for `angle.top` for instance because `angle.spheric.top` is the more appropriate form (top only applies to spheric but double applies to l and r).

Essentially, I've only done it when the symbol in the warning is a prefix of the symbol as specified in the source.