### PR TITLE
Rename `angle.right.sq` to `angle.right.square`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -650,6 +650,8 @@ angle ∠
   .right.rev ⯾
   .right.arc ⊾
   .right.dot ⦝
+  .right.square ⦜
+  @deprecated: `angle.right.sq` is deprecated, use `angle.right.square` instead
   .right.sq ⦜
   .s ⦞
   .spatial ⟀


### PR DESCRIPTION
Originally done in https://github.com/typst/codex/pull/110, accidentally reverted in https://github.com/typst/codex/pull/68.