### PR TITLE
Add Saudi riyal currency symbol

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -741,6 +741,7 @@ peso $
   .philippine ₱
 pound £
 riel ៛
+riyal ⃁
 ruble ₽
 rupee
   .indian ₹


### PR DESCRIPTION
This PR adds the symbol for the Saudi riyal currency, which was added to Unicode in version 17.0.0.

I chose the name `riyal` instead of something more specific because this is the only riyal in active use.[^1]

[^1]: According to @Enivex on Discord: https://discord.com/channels/1054443721975922748/1277628305142452306/1431770363737407562