### PR TITLE
Add narrow emptyset symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New in `sym`
 
 - Mathematical symbols
+  - `emptyset.zero`: ∅︀
+  - `nothing.zero`: ∅︀
   - `union.serif`: ∪︀
   - `union.sq.serif`: ⊔︀
   - `inter.serif`: ∩︀

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -401,12 +401,14 @@ asymp ≍
 
 // Set theory.
 emptyset ∅
+  .zero ∅\vs{1}
   .arrow.r ⦳
   .arrow.l ⦴
   .bar ⦱
   .circle ⦲
   .rev ⦰
 nothing ∅
+  .zero ∅\vs{1}
   .arrow.r ⦳
   .arrow.l ⦴
   .bar ⦱


### PR DESCRIPTION
I've gone with the modifier `.alt` for now, matching things like `pi.alt` etc. Please share any other ideas you might have