### PR TITLE
Add more `.not` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### New in `sym`
 
 - Mathematical symbols
+  - `in.small.not`: ∊̸
+  - `in.rev.small.not`: ∍̸
+  - `minus.tilde.not`: ≂̸
+  - `eq.quad.not`: ≣̸
+  - `lt.equiv.not`: ≦̸
+  - `gt.equiv.not`: ≧̸
+  - `lt.eq.slant.not`: ⩽̸
+  - `gt.eq.slant.not`: ⩾̸
   - `gt.double.nested`: ⪢
   - `lt.double.nested`: ⪡
   - `gt.arc` ⪧

--- a/build.rs
+++ b/build.rs
@@ -234,6 +234,23 @@ fn decode_value(mut text: &str) -> StrResult<String> {
             };
             result.push(vs);
             text = tail;
+        } else if let Some(rest) = text.strip_prefix("\\c{") {
+            let Some((value, tail)) = rest.split_once('}') else {
+                return Err(format!(
+                    "unclosed combining character escape: \\c{{{}",
+                    rest.escape_debug(),
+                ));
+            };
+            let c = match value {
+                "not" => '\u{0338}',
+                code => {
+                    return Err(format!(
+                        "invalid combining character escape: \\c{{{code}}}",
+                    ))
+                }
+            };
+            result.push(c);
+            text = tail;
         } else if let Some((prefix, tail)) = text.find('\\').map(|i| text.split_at(i)) {
             if prefix.is_empty() {
                 return Err(format!("invalid escape sequence: {tail}"));

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -260,6 +260,7 @@ minus −
   .plus ∓
   .square ⊟
   .tilde ≂
+  .tilde.not ≂\c{not}
   .triangle ⨺
 div ÷
   .o ⨸
@@ -302,6 +303,7 @@ eq =
   .triple ≡
   .triple.not ≢
   .quad ≣
+  .quad.not ≣\c{not}
 gt >
   .o ⧁
   .dot ⋗
@@ -312,9 +314,11 @@ gt >
   .double.nested ⪢
   .eq ≥
   .eq.slant ⩾
+  .eq.slant.not ⩾\c{not}
   .eq.lt ⋛
   .eq.not ≱
   .equiv ≧
+  .equiv.not ≧\c{not}
   .lt ≷
   .lt.not ≹
   .neq ⪈
@@ -340,9 +344,11 @@ lt <
   .double.nested ⪡
   .eq ≤
   .eq.slant ⩽
+  .eq.slant.not ⩽\c{not}
   .eq.gt ⋚
   .eq.not ≰
   .equiv ≦
+  .equiv.not ≦\c{not}
   .gt ≶
   .gt.not ≸
   .neq ⪇
@@ -419,7 +425,9 @@ in ∈
   .rev ∋
   .rev.not ∌
   .rev.small ∍
+  .rev.small.not ∍\c{not}
   .small ∊
+  .small.not ∊\c{not}
 subset ⊂
   .approx ⫉
   .closed ⫏


### PR DESCRIPTION
Some mathematical characters do not have a precomposed "not" variant. Instead, Unicode allows using U+0338 COMBINING LONG SOLIDUS OVERLAY to produce the negation of a character.

In this pull request, I added a few of those decomposed forms. More specifically, I added the ones that are listed in Table 2.8 of [UTR \#25](https://www.unicode.org/reports/tr25/) ([Table 9 in the recent proposed update](https://www.unicode.org/reports/tr25/tr25-16.html#table_using_vertical_line)) for which the base characters already have a name in Typst. I decided to stick to those for now as a starting point, but I definitely think we should add `.not` variants for all relations in the future.

Note that U+20D2 COMBINING LONG VERTICAL LINE OVERLAY is also a valid way to encode negation, but serves as an alternative to U+0338. If we decide to add them in the future, they would not be using `.not` (possible options include `.not.alt` or `.neg`).

Regarding font support, none of the few fonts I tested[^1] seem to support this for now in the sense that there does not seem to be specific glyphs for those symbols. Below is the result I get with New Computer Modern Math. We may want to reach out to the maintainer to make them aware of this Unicode feature.

<img width="100" height="104" alt="The combining slash is not placed very gracefully but the intent is still understandable." src="https://github.com/user-attachments/assets/b1f091d4-18e0-4d06-98c5-e9e52901b06d" />

[^1]: New Computer Modern Math, Fira Math, Libertinus Math and Lete Sans Math.