### PR TITLE
Test that all symbols use NFC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 name = "codex"
 version = "0.2.0"
 dependencies = [
+ "unicode-normalization",
  "ureq",
 ]
 
@@ -203,6 +204,30 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ keywords = ["unicode", "symbols"]
 [features]
 default = ["styling"]
 styling = []
-_test-unicode-conformance = ["ureq"]
+_test-unicode-conformance = ["ureq", "unicode-normalization"]
+
+[dependencies]
+unicode-normalization = { version = "0.1.25", optional = true }
 
 [build-dependencies]
 ureq = { version = "3.0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["unicode", "symbols"]
 default = ["numeral-systems", "styling"]
 numeral-systems = ["dep:chinese-number"]
 styling = []
-_test-unicode-conformance = ["ureq", "unicode-normalization"]
+_test-unicode-conformance = ["ureq", "dep:unicode-normalization"]
 
 [dependencies]
 chinese-number = { version = "0.7.7", default-features = false, features = ["number-to-chinese"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,10 +159,7 @@ mod test {
     #[test]
     fn random_sample() {
         for (key, control) in [
-            (
-                "backslash",
-                [("", "\\"), ("not", "⧷"), ("o", "⦸")].as_slice(),
-            ),
+            ("backslash", [("", "\\"), ("not", "⧷"), ("o", "⦸")].as_slice()),
             ("chi", &[("", "χ")]),
             ("forces", &[("", "⊩"), ("not", "⊮")]),
             ("interleave", &[("", "⫴"), ("big", "⫼"), ("struck", "⫵")]),
@@ -189,6 +186,17 @@ mod test {
 
             assert_eq!(variants, control);
         }
+    }
+
+    /// Tests that all symbols use NFC, i.e., use precomposed codepoints when
+    /// possible.
+    #[cfg(feature = "_test-unicode-conformance")]
+    #[test]
+    fn symbols_are_nfc() {
+        assert!(
+            are_all_variants_valid(ROOT, unicode_normalization::is_nfc),
+            "symbols should use NFC (see list above)",
+        )
     }
 
     /// https://www.unicode.org/reports/tr51/#def_text_presentation_selector.

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -750,13 +750,13 @@ note
   .up 🎜
   .down 🎝
   .whole 𝅝
-  .half 𝅗𝅥
-  .quarter 𝅘𝅥
+  .half 𝅗𝅥
+  .quarter 𝅘𝅥
   .quarter.alt ♩
-  .eighth 𝅘𝅥𝅮
+  .eighth 𝅘𝅥𝅮
   .eighth.alt ♪
   .eighth.beamed ♫
-  .sixteenth 𝅘𝅥𝅯
+  .sixteenth 𝅘𝅥𝅯
   .sixteenth.beamed ♬
   .grace 𝆕
   .grace.slash 𝆔


### PR DESCRIPTION
We probably want symbols to use NFC (i.e., the precomposed normalization form).

All the symbols currently part of Codex are already composed as much as possible, but sadly enforcing NFC has the effect of decomposing the music note symbols. For more information of why that is the case, see [UAX #15, "Post Composition Version Exclusions"](https://www.unicode.org/reports/tr15/#Exclusion_Types) and, to a lesser extent, the [Unicode Core Specification, Section 21.2.1, "Precomposed Note Characters"](https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-21/#G26751). TL;DR: This is for backward compatibility reasons.

This may be a reason to actually not enforce NFC, although the number of affect symbols is relatively small.[^1]

[^1]: https://www.unicode.org/Public/UCD/latest/ucd/CompositionExclusions.txt