### PR TITLE
Add dots.h.low as alias for .h

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -186,8 +186,9 @@ slash /
   .triple ⫻
   .big ⧸
 dots
-  .h.c ⋯
   .h …
+  .h.c ⋯
+  .h.low …
   .v ⋮
   .down ⋱
   .up ⋰


### PR DESCRIPTION
It seems that having `dots` default to the centered version was meant to be implemented already in https://github.com/typst/typst/pull/747 but that implementation was wrong (just changing the order of .h and .h.c without considering the number of modifiers).

Closes https://github.com/typst/codex/issues/147
