### PR TITLE
Add missing tacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
   - `tack.rrr`: ⫢
-  - `tacks.ll.rr`: ⟚
-  - `tacks.t.b.short`: ⫩
+  - `tacks.llrr`: ⟚
+  - `tacks.tb`: ⫩
 
 - Currency
   - `riyal`: ⃁
@@ -85,7 +85,7 @@
 - `lt.tri` and variants in favor of `lt.closed`
 - `join` and its variants in favor of `bowtie.big` with the same variants
 - `tack.r.double`, `tack.r.double.not`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
-- `tack.l.r` in favor of `tacks.l.r`.
+- `tack.l.r` in favor of `tacks.lr`.
 
 ### Removals **(Breaking change)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@
   - `bowtie.filled`: ⧓
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
+  - `tack.r.triple`: ⫢
+  - `ttack.r`: ⊩
+  - `ttack.r.not`: ⊮
+  - `ttack.r.double`: ⊫
+  - `ttack.r.double.not`: ⊯
+  - `ttack.l`: ⫣
+  - `ttack.l.double`: ⫥
+  - `ttack.t.short`: ⫨
+  - `ttack.b.short`: ⫧
+  - `tttack.r`: ⊪
 
 - Currency
   - `riyal`: ⃁

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,8 @@
   - `bowtie.filled`: ⧓
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
-  - `tack.ll.rr`: ⟚
-  - `tack.t.b.short`: ⫩
+  - `tacks.ll.rr`: ⟚
+  - `tacks.t.b.short`: ⫩
 
 - Currency
   - `riyal`: ⃁
@@ -84,6 +84,7 @@
 - `lt.tri` and variants in favor of `lt.closed`
 - `join` and its variants in favor of `bowtie.big` with the same variants
 - `tack.r.double`, `tack.r.double.not`, `tack.r.triple`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.rrr`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
+- `tack.l.r` in favor of `tacks.l.r`.
 
 ### Removals **(Breaking change)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,16 +61,8 @@
   - `bowtie.filled`: ⧓
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
-  - `tack.r.triple`: ⫢
-  - `ttack.r`: ⊩
-  - `ttack.r.not`: ⊮
-  - `ttack.r.double`: ⊫
-  - `ttack.r.double.not`: ⊯
-  - `ttack.l`: ⫣
-  - `ttack.l.double`: ⫥
-  - `ttack.t.short`: ⫨
-  - `ttack.b.short`: ⫧
-  - `tttack.r`: ⊪
+  - `tack.ll.rr`: ⟚
+  - `tack.t.b.short`: ⫩
 
 - Currency
   - `riyal`: ⃁
@@ -91,6 +83,7 @@
 - `gt.tri` and variants in favor of `gt.closed`
 - `lt.tri` and variants in favor of `lt.closed`
 - `join` and its variants in favor of `bowtie.big` with the same variants
+- `tack.r.double`, `tack.r.double.not`, `tack.r.triple`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.rrr`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
 
 ### Removals **(Breaking change)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
   - `bowtie.filled`: ⧓
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
+  - `tack.rrr`: ⫢
   - `tacks.ll.rr`: ⟚
   - `tacks.t.b.short`: ⫩
 
@@ -83,7 +84,7 @@
 - `gt.tri` and variants in favor of `gt.closed`
 - `lt.tri` and variants in favor of `lt.closed`
 - `join` and its variants in favor of `bowtie.big` with the same variants
-- `tack.r.double`, `tack.r.double.not`, `tack.r.triple`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.rrr`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
+- `tack.r.double`, `tack.r.double.not`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
 - `tack.l.r` in favor of `tacks.l.r`.
 
 ### Removals **(Breaking change)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,6 @@
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
   - `tack.rrr`: ⫢
-  - `tacks.llrr`: ⟚
-  - `tacks.tb`: ⫩
 
 - Currency
   - `riyal`: ⃁
@@ -85,7 +83,6 @@
 - `lt.tri` and variants in favor of `lt.closed`
 - `join` and its variants in favor of `bowtie.big` with the same variants
 - `tack.r.double`, `tack.r.double.not`, `tack.l.double`, `tack.t.double`, and `tack.b.double` in favor of `tack.rr`, `tack.rr.not`, `tack.ll`, `tack.tt`, and `tack.bb` respectively.
-- `tack.l.r` in favor of `tacks.lr`.
 
 ### Removals **(Breaking change)**
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1108,8 +1108,6 @@ tack
   @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.rr.not`
   .r.double.not ⊭
   .rr.not ⊭
-  @deprecated: `tack.triple` is deprecated, use `tack.rrr` instead
-  .r.triple ⫢
   .rrr ⫢
   .l ⊣
   .l.long ⟞

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1104,6 +1104,7 @@ tack
   .r.short ⊦
   .r.double ⊨
   .r.double.not ⊭
+  .r.triple ⫢
   .l ⊣
   .l.long ⟞
   .l.short ⫞
@@ -1117,6 +1118,17 @@ tack
   .b.double ⫪
   .b.short ⫟
   .l.r ⟛
+ttack
+  .r ⊩
+  .r.not ⊮
+  .r.double ⊫
+  .r.double.not ⊯
+  .l ⫣
+  .l.double ⫥
+  .t.short ⫨
+  .b.short ⫧
+tttack
+  .r ⊪
 
 // Lowercase Greek.
 alpha α

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1130,6 +1130,8 @@ tack
   .bb ⫪
   .b.short ⫟
   .l.r ⟛
+  .ll.rr ⟚
+  .t.b.short ⫩
 
 // Lowercase Greek.
 alpha α

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1127,12 +1127,12 @@ tack
   .b.double ⫪
   .bb ⫪
   .b.short ⫟
-  @deprecated: `tack.l.r` is deprecated, use `tacks.l.r` instead
+  @deprecated: `tack.l.r` is deprecated, use `tacks.lr` instead
   .l.r ⟛
 tacks
-  .l.r ⟛
-  .ll.rr ⟚
-  .t.b.short ⫩
+  .lr ⟛
+  .llrr ⟚
+  .tb ⫩
 
 // Lowercase Greek.
 alpha α

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1129,6 +1129,9 @@ tack
   .b.double ⫪
   .bb ⫪
   .b.short ⫟
+  @deprecated: `tack.l.r` is deprecated, use `tacks.l.r` instead
+  .l.r ⟛
+tacks
   .l.r ⟛
   .ll.rr ⟚
   .t.b.short ⫩

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1102,33 +1102,34 @@ tack
   .r.not ⊬
   .r.long ⟝
   .r.short ⊦
+  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.rr`
   .r.double ⊨
+  .rr ⊨
+  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.rr.not`
   .r.double.not ⊭
+  .rr.not ⊭
+  @deprecated: `tack.triple` is deprecated, use `tack.rrr` instead
   .r.triple ⫢
+  .rrr ⫢
   .l ⊣
   .l.long ⟞
   .l.short ⫞
+  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.ll`
   .l.double ⫤
+  .ll ⫤
   .t ⊥
   .t.big ⟘
+  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.tt`
   .t.double ⫫
+  .tt ⫫
   .t.short ⫠
   .b ⊤
   .b.big ⟙
+  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.bb`
   .b.double ⫪
+  .bb ⫪
   .b.short ⫟
   .l.r ⟛
-ttack
-  .r ⊩
-  .r.not ⊮
-  .r.double ⊫
-  .r.double.not ⊯
-  .l ⫣
-  .l.double ⫥
-  .t.short ⫨
-  .b.short ⫧
-tttack
-  .r ⊪
 
 // Lowercase Greek.
 alpha α

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1127,12 +1127,7 @@ tack
   .b.double ⫪
   .bb ⫪
   .b.short ⫟
-  @deprecated: `tack.l.r` is deprecated, use `tacks.lr` instead
   .l.r ⟛
-tacks
-  .lr ⟛
-  .llrr ⟚
-  .tb ⫩
 
 // Lowercase Greek.
 alpha α


### PR DESCRIPTION
- `tack.r.triple` was simply missing for no reason.
- `ttack.r` and `ttack.r.not` were already present as `forces` and `forces.not`. This adds all the other similar variants under non-semantic names because I don't think there is a good semantic name.
- There is no non-short version of `ttack.t.short` and `ttack.b.short` in Unicode AFAIK. `ttack.t` and `ttack.b` fall back to `ttack.t.short` and `ttack.b.short` respectively.
- The `.double` and `.triple` modifiers on `tack` are already used for something else, hence the proposed `ttack` and `tttack` symbols. Those names aren't the greatest but they are the best I was able to come up with. Feel free to make other suggestions.