### PR TITLE
Convert `dotless` to a submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ These previously deprecated items were removed:
 - `shin`
 - `planck.reduce`
 
+The `dotless` symbol was converted to a module,
+meaning you can no longer use `dotless` as a shorthand for `dotless.i`.
+
 ## Version 0.2.0 (October 7, 2025)
 
 ### General changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   meaning you can no longer use `dotless` as a shorthand for `dotless.i`. **(Breaking change)**
 
 ### Removals in `sym` **(Breaking change)**
+
 These previously deprecated items were removed:
 - `gt.tri.*`
 - `lt.tri.*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### General changes
+
+- The `dotless` symbol was converted to a module,
+  meaning you can no longer use `dotless` as a shorthand for `dotless.i`.
+
 ## Version 0.3.0 (June 4, 2026)
 
 ### General changes
@@ -192,9 +199,6 @@ These previously deprecated items were removed:
 - `dalet`
 - `shin`
 - `planck.reduce`
-
-The `dotless` symbol was converted to a module,
-meaning you can no longer use `dotless` as a shorthand for `dotless.i`.
 
 ## Version 0.2.0 (October 7, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### General changes
 
 - The `dotless` symbol was converted to a module,
-  meaning you can no longer use `dotless` as a shorthand for `dotless.i`.
+  meaning you can no longer use `dotless` as a shorthand for `dotless.i`. **(Breaking change)**
 
 ## Version 0.3.0 (June 4, 2026)
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1234,9 +1234,10 @@ pee ℘
 planck ħ
 Re ℜ
 Im ℑ
-dotless
-  .i ı
-  .j ȷ
+dotless {
+  i ı
+  j ȷ
+}
 
 // Miscellany.
 die


### PR DESCRIPTION
This makes more conceptual sense to me, since `dotless` on its own is meaningless.

This is a breaking change, so three approvals are necessary.

Note that there is no way to do a deprecation for this, but I don't think anyone was using `dotless` without modifiers anyway.