### PR TITLE
Add slanted variants of existing symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@
   - `lt.tilde.slant`: ≲︀
   - `smt.eq.slant`: ⪬︀
   - `lat.eq.slant`: ⪭︀
+  - `tilde.gt`: ⪞
+  - `tilde.gt.slant`: ⪞︀
+  - `tilde.lt`: ⪝
+  - `tilde.lt.slant`: ⪝︀
 
 - Miscellaneous technical
   - `bowtie.stroked`: ⋈

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@
   - `lt.closed.eq`: ⊴
   - `lt.closed.eq.not`: ⋬
   - `lt.closed.not`: ⋪
+  - `eq.gt.slant`: ⪖
+  - `eq.lt.slant`: ⪕
+  - `gt.eq.lt.slant`: ⋛︀
+  - `gt.equiv.slant`: ⫺
+  - `gt.tilde.slant`: ≳︀
+  - `lt.eq.gt.slant`: ⋚︀
+  - `tl.equiv.slant`: ⫹
+  - `lt.tilde.slant`: ≲︀
+  - `smt.eq.slant`: ⪬︀
+  - `lat.eq.slant`: ⪭︀
 
 - Miscellaneous technical
   - `bowtie.stroked`: ⋈
@@ -121,6 +131,8 @@
 
 - `gt.tri` and variants in favor of `gt.closed`
 - `lt.tri` and variants in favor of `lt.closed`
+- `prec.curly.eq` and variants in favor of `prec.eq.slant`
+- `succ.curly.eq` and variants in favor of `succ.eq.slant`
 - `join` and its variants in favor of `bowtie.big` with the same variants
 
 ### Removals **(Breaking change)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   - `lt.closed.not`: ⋪
   - `eq.gt.slant`: ⪖
   - `eq.lt.slant`: ⪕
+  - `equiv.gt`: ⪚
+  - `equiv.gt.slant`: ⪜
+  - `equiv.lt`: ⪙
+  - `equiv.lt.slant`: ⪛
   - `gt.eq.lt.slant`: ⋛︀
   - `gt.equiv.slant`: ⫺
   - `gt.tilde.slant`: ≳︀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,6 @@
 
 ## Unreleased
 
-### New in `sym`
-
-- Mathematical symbols
-  - `eq.gt.slant`: ⪖
-  - `eq.lt.slant`: ⪕
-  - `equiv.gt`: ⪚
-  - `equiv.gt.slant`: ⪜
-  - `equiv.lt`: ⪙
-  - `equiv.lt.slant`: ⪛
-  - `gt.eq.lt.slant`: ⋛︀
-  - `gt.equiv.slant`: ⫺
-  - `gt.tilde.slant`: ≳︀
-  - `lt.eq.gt.slant`: ⋚︀
-  - `tl.equiv.slant`: ⫹
-  - `lt.tilde.slant`: ≲︀
-  - `smt.eq.slant`: ⪬︀
-  - `lat.eq.slant`: ⪭︀
-  - `tilde.gt`: ⪞
-  - `tilde.gt.slant`: ⪞︀
-  - `tilde.lt`: ⪝
-  - `tilde.lt.slant`: ⪝︀
-
-### Deprecations in `sym`
-
-- `prec.curly.eq` and variants in favor of `prec.eq.slant`
-- `succ.curly.eq` and variants in favor of `succ.eq.slant`
-
 ### Removals in `sym` **(Breaking change)**
 These previously deprecated items were removed:
 - `gt.tri.*`

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -202,6 +202,10 @@ tilde
   .equiv ≅
   .equiv.not ≇
   .nequiv ≆
+  .lt ⪝
+  .lt.slant ⪝\vs{1}
+  .gt ⪞
+  .gt.slant ⪞\vs{1}
   .not ≁
   .rev ∽
   .rev.equiv ≌

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -422,6 +422,10 @@ succ ≻
   .tilde ≿
 equiv ≡
   .not ≢
+  .lt ⪙
+  .lt.slant ⪛
+  .gt ⪚
+  .gt.slant ⪜
 smt ⪪
   .eq ⪬
   .eq.slant ⪬\vs{1}

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -294,7 +294,9 @@ eq =
   .equi ≚
   .est ≙
   .gt ⋝
+  .gt.slant ⪖
   .lt ⋜
+  .lt.slant ⪕
   .m ≞
   .not ≠
   .prec ⋞
@@ -318,8 +320,10 @@ gt >
   .eq ≥
   .eq.slant ⩾
   .eq.lt ⋛
+  .eq.lt.slant ⋛\vs{1}
   .eq.not ≱
   .equiv ≧
+  .equiv.slant ⫺
   .lt ≷
   .lt.not ≹
   .neq ⪈
@@ -328,6 +332,7 @@ gt >
   .not ≯
   .ntilde ⋧
   .tilde ≳
+  .tilde.slant ≳\vs{1}
   .tilde.not ≵
   @deprecated: `gt.tri` is deprecated, use `gt.closed` instead
   .tri ⊳
@@ -354,8 +359,10 @@ lt <
   .eq ≤
   .eq.slant ⩽
   .eq.gt ⋚
+  .eq.gt.slant ⋚\vs{1}
   .eq.not ≰
   .equiv ≦
+  .equiv.slant ⫹
   .gt ≶
   .gt.not ≸
   .neq ⪇
@@ -364,6 +371,7 @@ lt <
   .not ≮
   .ntilde ⋦
   .tilde ≲
+  .tilde.slant ≲\vs{1}
   .tilde.not ≴
   @deprecated: `lt.tri` is deprecated, use `lt.closed` instead
   .tri ⊲
@@ -380,10 +388,14 @@ approx ≈
   .not ≉
 prec ≺
   .approx ⪷
+  @deprecated: `prec.curly.eq` is deprecated, use `prec.eq.slant` instead
   .curly.eq ≼
+  @deprecated: `prec.curly.eq` is deprecated, use `prec.eq.slant` instead
   .curly.eq.not ⋠
   .double ⪻
   .eq ⪯
+  .eq.slant ≼
+  .eq.slant.not ⋠
   .equiv ⪳
   .napprox ⪹
   .neq ⪱
@@ -393,10 +405,14 @@ prec ≺
   .tilde ≾
 succ ≻
   .approx ⪸
+  @deprecated: `succ.curly.eq` is deprecated, use `succ.eq.slant` instead
   .curly.eq ≽
+  @deprecated: `succ.curly.eq` is deprecated, use `succ.eq.slant` instead
   .curly.eq.not ⋡
   .double ⪼
   .eq ⪰
+  .eq.slant ≽
+  .eq.slant.not ⋡
   .equiv ⪴
   .napprox ⪺
   .neq ⪲
@@ -408,8 +424,10 @@ equiv ≡
   .not ≢
 smt ⪪
   .eq ⪬
+  .eq.slant ⪬\vs{1}
 lat ⪫
   .eq ⪭
+  .eq.slant ⪭\vs{1}
 prop ∝
 original ⊶
 image ⊷


### PR DESCRIPTION
This supersedes #111, with the same motivation of giving a not-so-bad name to slanted-equal variants until we find a more general solution (if that happens). This also unblocks https://github.com/typst/codex/pull/36.

Compared to @Enivex's PR, I did not add the `.dot` variants because they are part of a greater family.

The breaking change is the deprecation of `{prec,succ}.curly.eq.*` in favor of `{prec,succ}.eq.slant.*`.