### PR TITLE
Add `zero.slashed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   - `lt.closed.not`: ⋪
 
 - Miscellaneous technical
+  - `zero`: 0
+  - `zero.slashed`: 0︀
   - `bowtie.stroked`: ⋈
   - `bowtie.stroked.big`: ⨝
   - `bowtie.stroked.big.l`: ⟕

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1118,6 +1118,9 @@ tack
   .b.short ⫟
   .l.r ⟛
 
+zero 0
+  .slashed 0\vs{1}
+
 // Lowercase Greek.
 alpha α
 beta β

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1118,7 +1118,7 @@ tack
   .b.short ⫟
   .l.r ⟛
 
-zero 0
+zero 0\vs{text}
   .slashed 0\vs{1}
 
 // Lowercase Greek.


### PR DESCRIPTION
This assigns the name `zero.slashed` to the _DIGIT ZERO short diagonal stroke form_ variation sequence.

`zero` alone is mapped to a regular `0` ~with no variation selector~ with a text variation selector.