### PR TITLE
Add some decorated symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
   - `lt.closed.eq.not`: ⋬
   - `lt.closed.not`: ⋪
 
+- Decorated mathematical symbols
+  - `plus.hat`: ⨣
+  - `approx.hat`: ⩯
+
 - Miscellaneous technical
   - `bowtie.stroked`: ⋈
   - `bowtie.stroked.big`: ⨝

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
   - `approx.hat`: ⩯
   - `lt.quest`: ⩻
   - `gt.quest`: ⩼
+  - `eq.ast`: ⩮
 
 - Miscellaneous technical
   - `bowtie.stroked`: ⋈

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 - Decorated mathematical symbols
   - `plus.hat`: ⨣
   - `approx.hat`: ⩯
+  - `lt.quest`: ⩻
+  - `gt.quest`: ⩼
 
 - Miscellaneous technical
   - `bowtie.stroked`: ⋈

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -307,6 +307,7 @@ eq =
 gt >
   .o ⧁
   .dot ⋗
+  .quest ⩼
   .approx ⪆
   .arc ⪧
   .arc.eq ⪩
@@ -343,6 +344,7 @@ gt >
 lt <
   .o ⧀
   .dot ⋖
+  .quest ⩻
   .approx ⪅
   .arc ⪦
   .arc.eq ⪨

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -255,6 +255,7 @@ plus +
   .square ⊞
   .triangle ⨹
   .triple ⧻
+  .hat ⨣
 minus −
   .o ⊖
   .dot ∸
@@ -378,6 +379,7 @@ lt <
 approx ≈
   .eq ≊
   .not ≉
+  .hat ⩯
 prec ≺
   .approx ⪷
   .curly.eq ≼

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -284,6 +284,7 @@ ratio ∶
 
 // Relations.
 eq =
+  .ast ⩮
   .star ≛
   .o ⊜
   .colon ≕


### PR DESCRIPTION
This adds a few symbols that are decorated with smaller symbols:
- `.hat` has precedent in ⨶ `times.o.hat`.
- `.quest` has precedent in ≟ `eq.quest`.
- `.ast` is used as a modifier for the first time here, but consistent with ∗ `ast` (which falls back to `ast.op`).