### PR TITLE
Add a few more arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   - `arrow.br.bar`: 🢺
   - `arrow.tl.bar`: 🢸
   - `arrow.bl.bar`: 🢻
+  - `arrows.rl.long`: 🣐
 
 - Currency
   - `riyal`: ⃁

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@
   - `bowtie.filled.l`: ⧑
   - `bowtie.filled.r`: ⧒
 
+- Arrows
+  - `arrow.tr.bar`: 🢹
+  - `arrow.br.bar`: 🢺
+  - `arrow.tl.bar`: 🢸
+  - `arrow.bl.bar`: 🢻
+
 - Currency
   - `riyal`: ⃁
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1010,21 +1010,25 @@ arrow
   .t.b.filled ⬍
   .t.b.stroked ⇳
   .tr ↗\vs{text}
+  .tr.bar 🢹
   .tr.double ⇗
   .tr.filled ⬈
   .tr.hook ⤤
   .tr.stroked ⬀
   .br ↘\vs{text}
+  .br.bar 🢺
   .br.double ⇘
   .br.filled ⬊
   .br.hook ⤥
   .br.stroked ⬂
   .tl ↖\vs{text}
+  .tl.bar 🢸
   .tl.double ⇖
   .tl.filled ⬉
   .tl.hook ⤣
   .tl.stroked ⬁
   .bl ↙\vs{text}
+  .bl.bar 🢻
   .bl.double ⇙
   .bl.filled ⬋
   .bl.hook ⤦

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1048,6 +1048,7 @@ arrows
   .lr ⇆
   .lr.stop ↹
   .rl ⇄
+  .rl.long 🣐
   .tb ⇅
   .bt ⇵
   .rrr ⇶


### PR DESCRIPTION
Those arrows are from Unicode 16.0 and 17.0 and supported by New Computer Modern Math 8.0.0. There are other arrows from those Unicode versions, but they are less easy to name so let's focus on the easy ones for now.