### PR TITLE
Bump transitive `rustls-webpki` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ name = "codex"
 version = "0.2.0"
 dependencies = [
  "chinese-number",
+ "rustls-webpki",
  "siphasher",
  "ureq",
 ]
@@ -275,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["unicode", "symbols"]
 default = ["numeral-systems", "styling"]
 numeral-systems = ["dep:chinese-number"]
 styling = []
-_test-unicode-conformance = ["ureq"]
+_test-unicode-conformance = ["dep:ureq", "dep:rustls-webpki"]
 
 [dependencies]
 chinese-number = { version = "0.7.7", default-features = false, features = ["number-to-chinese"], optional = true }
@@ -25,3 +25,5 @@ siphasher = "1.0.2"
 
 [build-dependencies]
 ureq = { version = "3.0.12", optional = true }
+# Security fix. Can be removed again with a ureq update that transitively depends on at least this version.
+rustls-webpki = { version = "0.103.13", optional = true }


### PR DESCRIPTION
...so that I can stop getting the annoying dependabot alert E-mails.
(I also considered changing my notif settings, but since there's apparently a vulnerability, why not stop people from running vulnerable code when running the tests that fetch something from the web)

We can then later remove the extra dependency line again after `ureq` updates its `rustls` dependency and we update to that newer `ureq` version.
