### PR TITLE
Fix two emoji

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,8 +242,12 @@ mod test {
         let sequences = get_valid_presentation_sequences();
         assert!(
             are_all_variants_valid(ROOT, |c| {
+                // FIXME: Some emoji consist of many characters and contain an
+                // emoji presentation sequence in the middle, but are not listed
+                // in emoji-variation-sequences.txt.
+                // See: https://github.com/typst/codex/issues/166.
                 if c.contains(TEXT_PRESENTATION_SELECTOR)
-                    || c.contains(EMOJI_PRESENTATION_SELECTOR)
+                    || c.ends_with(EMOJI_PRESENTATION_SELECTOR)
                 {
                     sequences.contains(c)
                 } else {

--- a/src/modules/emoji.txt
+++ b/src/modules/emoji.txt
@@ -45,7 +45,7 @@ arrow
   .tr ↗\vs{emoji}
 arrows
   .cycle 🔄
-ast *\vs{emoji}
+ast *\vs{emoji}\u{20E3}
   .box ✳\vs{emoji}
 atm 🏧
 atom ⚛\vs{emoji}
@@ -720,7 +720,7 @@ hands
   .raised 🙌
   .shake 🤝
 harp 🪉
-hash #\vs{emoji}
+hash #\vs{emoji}\u{20E3}
 hat
   .ribbon 👒
   .top 🎩


### PR DESCRIPTION
Two emoji are missing a combining enclosing keycap component. With this fix, all emoji in `emoji` should be part of https://www.unicode.org/Public/17.0.0/emoji/emoji-test.txt, and more specifically https://unicode.org/emoji/charts/emoji-ordering.txt, which seems to only include fully-qualified forms and components.

Related: https://github.com/typst/codex/issues/166.