### PR TITLE
Remove 0.3.0 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,8 @@
 
 ### Removals in `sym` **(Breaking change)**
 These previously deprecated items were removed:
-- `gt.tri`
-- `gt.tri.eq`
-- `gt.tri.not`
-- `gt.tri.eq.not`
-- `lt.tri`
-- `lt.tri.eq`
-- `lt.tri.not`
-- `lt.tri.eq.not`
+- `gt.tri.*`
+- `lt.tri.*`
 - `join`, `join.*`
 - `tack.r.double`
 - `tack.r.double.not`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Removals in `sym` **(Breaking change)**
+These previously deprecated items were removed:
+- `gt.tri`
+- `gt.tri.eq`
+- `gt.tri.not`
+- `gt.tri.eq.not`
+- `lt.tri`
+- `lt.tri.eq`
+- `lt.tri.not`
+- `lt.tri.eq.not`
+- `join`, `join.*`
+- `tack.r.double`
+- `tack.r.double.not`
+- `tack.l.double`
+- `tack.t.double`
+- `tack.b.double`
+
 ## Version 0.3.0 (June 4, 2026)
 
 ### General changes

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -333,14 +333,6 @@ gt >
   .ntilde ⋧
   .tilde ≳
   .tilde.not ≵
-  @deprecated: `gt.tri` is deprecated, use `gt.closed` instead
-  .tri ⊳
-  @deprecated: `gt.tri.eq` is deprecated, use `gt.closed.eq` instead
-  .tri.eq ⊵
-  @deprecated: `gt.tri.eq.not` is deprecated, use `gt.closed.eq.not` instead
-  .tri.eq.not ⋭
-  @deprecated: `gt.tri.not` is deprecated, use `gt.closed.not` instead
-  .tri.not ⋫
   .triple ⋙
   .triple.nested ⫸
 lt <
@@ -370,14 +362,6 @@ lt <
   .ntilde ⋦
   .tilde ≲
   .tilde.not ≴
-  @deprecated: `lt.tri` is deprecated, use `lt.closed` instead
-  .tri ⊲
-  @deprecated: `lt.tri.eq` is deprecated, use `lt.closed.eq` instead
-  .tri.eq ⊴
-  @deprecated: `lt.tri.eq.not` is deprecated, use `lt.closed.eq.not` instead
-  .tri.eq.not ⋬
-  @deprecated: `lt.tri.not` is deprecated, use `lt.closed.not` instead
-  .tri.not ⋪
   .triple ⋘
   .triple.nested ⫷
 approx ≈
@@ -647,11 +631,6 @@ diameter ⌀
 interleave ⫴
   .big ⫼
   .struck ⫵
-@deprecated: `join` is deprecated, use `bowtie.big` instead
-join ⨝
-  .r ⟖
-  .l ⟕
-  .l.r ⟗
 bowtie
   .stroked ⋈
   .stroked.big ⨝
@@ -1115,29 +1094,19 @@ tack
   .r.not ⊬
   .r.long ⟝
   .r.short ⊦
-  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.rr`
-  .r.double ⊨
   .rr ⊨
-  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.rr.not`
-  .r.double.not ⊭
   .rr.not ⊭
   .rrr ⫢
   .l ⊣
   .l.long ⟞
   .l.short ⫞
-  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.ll`
-  .l.double ⫤
   .ll ⫤
   .t ⊥
   .t.big ⟘
-  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.tt`
-  .t.double ⫫
   .tt ⫫
   .t.short ⫠
   .b ⊤
   .b.big ⟙
-  @deprecated: `tack.double` is deprecated, use repeated letters instead, e.g., `tack.bb`
-  .b.double ⫪
   .bb ⫪
   .b.short ⫟
   .l.r ⟛


### PR DESCRIPTION
Since 0.3.0 is released now, I quickly did this to make sure we don't forget about it.
This PR should stay open until the Typst 0.15.0 release tho, in case we end up needing a 0.3.1 release.