### PR TITLE
Add missing tacks (part II)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,35 @@
 
 ## Unreleased
 
-### Removals in `sym` **(Breaking change)**
-These previously deprecated items were removed:
-- `gt.tri.*`
-- `lt.tri.*`
-- `join`, `join.*`
+## New in `sym`
+
+- Miscellaneous technical
+  - `tack.r.double` ⊩
+  - `tack.r.double.not` ⊮
+  - `tack.r.triple` ⊪
+  - `tack.rr.short` ⊧
+  - `tack.rr.double` ⊫
+  - `tack.rr.double.not` ⊯
+  - `tack.l.double` ⫣
+  - `tack.ll.double` ⫥
+  - `tack.t.double.short` ⫨
+  - `tack.b.double.short` ⫧
+
+### Changed values in `sym` **(Breaking change)**
+
+These previously deprecated items were undeprecated with a changed value:
 - `tack.r.double`
 - `tack.r.double.not`
 - `tack.l.double`
 - `tack.t.double`
 - `tack.b.double`
+
+### Removals in `sym` **(Breaking change)**
+
+These previously deprecated items were removed:
+- `gt.tri.*`
+- `lt.tri.*`
+- `join`, `join.*`
 
 ## Version 0.3.0 (June 4, 2026)
 

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1103,12 +1103,12 @@ tack
   .ll ⫤
   .t ⊥
   .t.big ⟘
-  .tt ⫫
   .t.short ⫠
+  .tt ⫫
   .b ⊤
   .b.big ⟙
-  .bb ⫪
   .b.short ⫟
+  .bb ⫪
   .l.r ⟛
 
 zero 0\vs{text}

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -1094,20 +1094,30 @@ tack
   .r.not ⊬
   .r.long ⟝
   .r.short ⊦
+  .r.double ⊩
+  .r.double.not ⊮
+  .r.triple ⊪
   .rr ⊨
   .rr.not ⊭
+  .rr.short ⊧
+  .rr.double ⊫
+  .rr.double.not ⊯
   .rrr ⫢
   .l ⊣
   .l.long ⟞
   .l.short ⫞
+  .l.double ⫣
   .ll ⫤
+  .ll.double ⫥
   .t ⊥
   .t.big ⟘
   .t.short ⫠
+  .t.double.short ⫨
   .tt ⫫
   .b ⊤
   .b.big ⟙
   .b.short ⫟
+  .b.double.short ⫧
   .bb ⫪
   .l.r ⟛
 


### PR DESCRIPTION
This is a follow-up to #151.

Some of the names we use in this PR were made available for this purpose by the deprecations introduced in #151.