### PR TITLE
Add ordinal ª and º indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New in `sym`
+
+- Ordinal indicators
+  - `ordinal.a`: ª
+  - `ordinal.o`: º
+
 ### Removals in `sym` **(Breaking change)**
 These previously deprecated items were removed:
 - `gt.tri.*`

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -732,9 +732,10 @@ suit
   .heart.stroked ♡
   .spade.filled ♠\vs{text}
   .spade.stroked ♤
-ordinal
-  .a ª
-  .o º
+ordinal {
+  a ª
+  o º
+}
 
 // Music.
 note

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -732,6 +732,9 @@ suit
   .heart.stroked ♡
   .spade.filled ♠\vs{text}
   .spade.stroked ♤
+ordinal
+  .a ª
+  .o º
 
 // Music.
 note

--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -733,8 +733,8 @@ suit
   .spade.filled ♠\vs{text}
   .spade.stroked ♤
 ordinal {
-  a ª
-  o º
+  feminine ª
+  masculine º
 }
 
 chess {


### PR DESCRIPTION
This pull request adds the [ordinal indicators](https://en.wikipedia.org/wiki/Ordinal_indicator) ª and º.

| character | Unicode value | symbol |
| - | - | - |
| ª | U+00AA FEMININE ORDINAL INDICATOR | `ordinal.a` |
| º | U+00BA MASCULINE ORDINAL INDICATOR | `ordinal.o` |