### PR TITLE
Add `not.inv` and `not.rev`

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -536,6 +536,8 @@ exists ∃
 top ⊤
 bot ⊥
 not ¬
+  .inv ⌙
+  .rev ⌐
 and ∧
   .big ⋀
   .curly ⋏


### PR DESCRIPTION
`not.inv` is consistent with `quest.inv` (¿). `not.rev` is consistent with `in.rev` (∋).