### PR TITLE
Add more stacked tilde variants

### DIFF
--- a/src/modules/sym.txt
+++ b/src/modules/sym.txt
@@ -196,9 +196,12 @@ tilde
   .op ∼
   .basic ~
   .dot ⩪
+  .double ≈
+  .double.not ≉
   .eq ≃
   .eq.not ≄
   .eq.rev ⋍
+  .eq.tilde ⩬
   .equiv ≅
   .equiv.not ≇
   .nequiv ≆
@@ -265,6 +268,7 @@ minus −
   .dot ∸
   .plus ∓
   .square ⊟
+  @deprecated: `minus.tilde` is deprecated, use `eq.tilde` instead
   .tilde ≂
   .triangle ⨺
 div ÷
@@ -309,6 +313,7 @@ eq =
   .prec ⋞
   .quest ≟
   .succ ⋟
+  .tilde ≂
   .triple ≡
   .triple.not ≢
   .quad ≣
@@ -378,6 +383,7 @@ lt <
   .triple.nested ⫷
 approx ≈
   .eq ≊
+  .equiv ⩰
   .not ≉
   .hat ⩯
 prec ≺
@@ -420,6 +426,7 @@ equiv ≡
   .lt.slant ⪛
   .gt ⪚
   .gt.slant ⪜
+  .tilde ⩳
 smt ⪪
   .eq ⪬
   .eq.slant ⪬\vs{1}


### PR DESCRIPTION
This adds a few symbols composed of stacked tildes and horizontal lines. I explain the reasoning for each change below.

- `tilde.double` makes sense in my opinion as a non-semantic variant of `approx`. I have chosen to only include the `.not` variant but I am open to including `.eq`, `.equiv`, and `.hat` as well. I am also open to excluding `tilde.double` from this PR if we are unable to reach a consensus.

- The rename from `minus.tilde` to `eq.tilde` is consistent with the existing `tilde.eq`, as well as the Unicode character being a Relation, not a Binary, even though its name uses "MINUS" instead of "EQUAL". Same for `tilde.eq.tilde`.

- `equiv.tilde` is consistent with the existing `tilde.equiv`.

- `approx.equiv` is consistent with other uses of `.equiv`, such as in `tilde.equiv`.